### PR TITLE
Adding apis that get info from llamastack

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from .database import engine, Base, AsyncSessionLocal
-from .routes import users, mcp_servers, knowledge_bases, virtual_assistants, chat_history, guardrails, model_servers
+from .routes import users, mcp_servers, knowledge_bases, virtual_assistants, chat_history, guardrails, model_servers, llama_stack
+import logging
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.ext.asyncio import AsyncSession
 from dotenv import load_dotenv
@@ -8,6 +9,12 @@ import os
 
 load_dotenv()
 
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
 
 app = FastAPI()
 
@@ -51,6 +58,4 @@ app.include_router(virtual_assistants.router)
 app.include_router(chat_history.router)
 app.include_router(guardrails.router)
 app.include_router(model_servers.router)
-
-
-
+app.include_router(llama_stack.router)

--- a/backend/routes/llama_stack.py
+++ b/backend/routes/llama_stack.py
@@ -1,0 +1,133 @@
+from fastapi import APIRouter, HTTPException, status
+from llama_stack_client import LlamaStackClient
+from typing import List, Dict, Any
+import logging
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/llama_stack", tags=["llama_stack"])
+
+# Initialize LlamaStack client
+client = LlamaStackClient(base_url="http://localhost:8321")
+
+@router.get("/llms", response_model=List[Dict[str, Any]])
+async def get_llms():
+    """Get available LLMs from LlamaStack"""
+    try:
+        log.info(f"Attempting to fetch models from LlamaStack at {client.base_url}")
+        try:
+            models = client.models.list()
+            log.info(f"Received response from LlamaStack: {models}")
+        except Exception as client_error:
+            log.error(f"Error calling LlamaStack API: {str(client_error)}")
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=f"Failed to connect to LlamaStack API: {str(client_error)}"
+            )
+
+        if not models:
+            log.warning("No models returned from LlamaStack")
+            return []
+
+        llms = []
+        for model in models:
+            try:
+                if model.model_type == "llm":
+                    llm_config = {
+                        "id": str(model.identifier),
+                        "name": model.provider_resource_id,
+                        "model_type": model.model_type,
+                    }
+                    llms.append(llm_config)
+            except AttributeError as ae:
+                log.error(f"Error processing model data: {str(ae)}. Model data: {model}")
+                continue
+
+        log.info(f"Successfully processed {len(llms)} LLM models")
+        return llms
+
+    except Exception as e:
+        log.error(f"Unexpected error in get_llms: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Internal server error: {str(e)}"
+        )
+
+@router.get("/knowledge_bases", response_model=List[Dict[str, Any]])
+async def get_knowledge_bases():
+    """Get available knowledge bases from LlamaStack"""
+    try:
+        kbs = client.vector_dbs.list()
+        return [{
+            "id": str(kb.id),
+            "name": kb.name,
+            "version": kb.version,
+        } for kb in kbs]
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.get("/mcp_servers", response_model=List[Dict[str, Any]])
+async def get_mcp_servers():
+    """Get available MCP servers from LlamaStack"""
+    try:
+        servers = client.toolgroups.list()
+        return [{
+            "id": str(server.identifier),
+            "name": server.provider_resource_id,
+            "title": server.provider_id,
+        } for server in servers]
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.get("/safety_models", response_model=List[Dict[str, Any]])
+async def get_safety_models():
+    """Get available safety models from LlamaStack"""
+    try:
+        models = client.models.list()
+        safety_models = []
+        for model in models:
+            if model.model_type == "safety":
+                safety_model = {
+                    "id": str(model.identifier),
+                    "name": model.provider_resource_id,
+                    "model_type": model.type,
+                }
+                safety_models.append(safety_model)
+        return safety_models
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.get("/embedding_models", response_model=List[Dict[str, Any]])
+async def get_embedding_models():
+    """Get available embedding models from LlamaStack"""
+    try:
+        models = client.models.list()
+        embedding_models = []
+        for model in models:
+            if model.model_type == "embedding":
+                embedding_model = {
+                    "id": str(model.identifier),
+                    "name": model.provider_resource_id,
+                    "model_type": model.type,
+                }
+                embedding_models.append(embedding_model)
+        return embedding_models
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.get("/shields", response_model=List[Dict[str, Any]])
+async def get_shields():
+    """Get available shields from LlamaStack"""
+    try:
+        shields = client.shields.list()
+        shields_list = []
+        for shield in shields:
+            shield = {
+                    "id": str(shield.identifier),
+                    "name": shield.provider_resource_id,
+                    "model_type": shield.type,
+                }
+            shields_list.append(shield)
+        return shields_list
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
The following apis have been added so frontends can access llama stack without llama stack being exposed to external traffic.

/llama_stack/llms
/llama_stack/knowledge_bases
/llama_stack/mcp_servers
/llama_stack/safety_models
/llama_stack/embedding_models
/llama_stack/shields

Fields are aligned with interfaces defined in admin/src/pages/Dashboard.tsx

One of the #TODOs here is to get the llama stack url from an environment variable or other configurable means instead of it being hard coded.