### PR TITLE
Agent config changes to enable tool calling

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -25,7 +25,6 @@ class User(Base):
     chat_histories = relationship("ChatHistory", back_populates="user")
     mcp_servers = relationship("MCPServer", back_populates="creator")
     knowledge_bases = relationship("KnowledgeBase", back_populates="creator")
-    virtual_assistants = relationship("VirtualAssistant", back_populates="creator")
     guardrails = relationship("Guardrail", back_populates="creator")
 
 class ToolTypeEnum(enum.Enum):
@@ -58,14 +57,11 @@ class KnowledgeBase(Base):
     created_at = Column(TIMESTAMP(timezone=True), server_default=func.now())
     updated_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), onupdate=func.now())
     creator = relationship("User", back_populates="knowledge_bases")
-    va_links = relationship("VirtualAssistantKnowledgeBase", back_populates="knowledge_base")
     
 
 class ChatHistory(Base):
     __tablename__ = "chat_history"
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    virtual_assistant_id = Column(UUID(as_uuid=True), ForeignKey("virtual_assistants.id"))
-    virtual_assistant = relationship("VirtualAssistant", back_populates="chat_histories")
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"))
     user = relationship("User", back_populates="chat_histories")
     message = Column(Text, nullable=False)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -26,7 +26,7 @@ class UserRead(UserBase):
     updated_at: Any
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 # MCPServer Schemas
 class MCPServerBase(BaseModel):
@@ -45,7 +45,7 @@ class MCPServerRead(MCPServerBase):
     updated_at: Any
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 # KnowledgeBase Schemas
 class KnowledgeBaseBase(BaseModel):
@@ -67,7 +67,7 @@ class KnowledgeBaseRead(KnowledgeBaseBase):
     updated_at: Any
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 # Tool Association Info for VirtualAssistant
 class ToolAssociationInfo(BaseModel):
@@ -114,7 +114,7 @@ class VirtualAssistantUpdate(VirtualAssistantBase):
 class VirtualAssistantRead(VirtualAssistantBase):
     id: str
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 class ChatHistoryBase(BaseModel):
     virtual_assistant_id: UUID4
@@ -130,7 +130,7 @@ class ChatHistoryRead(ChatHistoryBase):
     created_at: Any
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 class GuardrailBase(BaseModel):
     name: str
@@ -146,7 +146,7 @@ class GuardrailRead(GuardrailBase):
     updated_at: Any
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 # ModelServer Schemas (These seemed largely okay with your models.py)
 class ModelServerBase(BaseModel):
@@ -170,4 +170,4 @@ class ModelServerRead(ModelServerBase):
     id: UUID4
 
     class Config:
-        orm_mode = True
+        from_attributes = True

--- a/backend/virtual_agents/agents.py
+++ b/backend/virtual_agents/agents.py
@@ -1,3 +1,4 @@
+from http.client import HTTPException
 from llama_stack_client import Agent
 from llama_stack_client.lib.agents.react.agent import ReActAgent
 from typing import Optional, List, Union, Any, Tuple, Callable
@@ -16,32 +17,30 @@ class ExistingAgent(Agent):
         self,
         client,
         agent_id: str,
+        agent_config: Optional[AgentConfig] = None,
         model: Optional[str] = None,
         instructions: Optional[str] = None,
         tools: Optional[List[Union[Toolgroup, ClientTool, Callable[..., Any]]]] = None,
         tool_config: Optional[ToolConfig] = None,
         sampling_params: Optional[SamplingParams] = None,
         max_infer_iters: Optional[int] = None,
-        agent_config: Optional[AgentConfig] = None,
         client_tools: Tuple[ClientTool, ...] = (),
         tool_parser: Optional[ToolParser] = None,
     ):
-        # Call parent's __init__ but skip the initialize() call
+  
         self.client = client
-        self.model = model
-        self.instructions = instructions
-        self.tools = tools or []
-        self.tool_config = tool_config
-        self.sampling_params = sampling_params
-        self.max_infer_iters = max_infer_iters
+        self.agent_id = agent_id
         self.agent_config = agent_config
-        self.client_tools = client_tools
+        self.model = agent_config.get("model", None)
+        self.instructions = agent_config.get("instructions", None)
+        self.tools = agent_config.get("toolgroups", [])
+        self.tool_config = agent_config.get("tool_config", None)
+        self.sampling_params = agent_config.get("sampling_params", None)
+        self.max_infer_iters = agent_config.get("max_infer_iters", None)
+        self.client_tools = agent_config.get("client_tools", [])
         self.tool_parser = tool_parser
         self.sessions = []
         self.builtin_tools = {}
-        
-        # Set the agent_id directly instead of calling initialize()
-        self.agent_id = agent_id
 
 
 class ExistingReActAgent(ReActAgent):
@@ -51,29 +50,27 @@ class ExistingReActAgent(ReActAgent):
         self,
         client,
         agent_id: str,
+        agent_config: Optional[AgentConfig] = None,
         model: Optional[str] = None,
         tools: Optional[List[Union[Toolgroup, ClientTool, Callable[..., Any]]]] = None,
         tool_config: Optional[ToolConfig] = None,
         sampling_params: Optional[SamplingParams] = None,
         max_infer_iters: Optional[int] = None,
-        response_format: Optional[dict] = None,
-        agent_config: Optional[AgentConfig] = None,
         client_tools: Tuple[ClientTool, ...] = (),
+        response_format: Optional[dict] = None,
         tool_parser: Optional[ToolParser] = None,
     ):
-        # Call parent's __init__ but skip the initialize() call
+
         self.client = client
-        self.model = model
-        self.tools = tools or []
-        self.tool_config = tool_config
-        self.sampling_params = sampling_params
-        self.max_infer_iters = max_infer_iters
-        self.response_format = response_format
+        self.agent_id = agent_id
         self.agent_config = agent_config
-        self.client_tools = client_tools
+        self.model = agent_config.get("model", None)
+        self.tools = agent_config.get("toolgroups", [])
+        self.tool_config = agent_config.get("tool_config", None)
+        self.sampling_params = agent_config.get("sampling_params", None)
+        self.max_infer_iters = agent_config.get("max_infer_iters", None)
+        self.client_tools = agent_config.get("client_tools", [])
+        self.response_format = response_format
         self.tool_parser = tool_parser
         self.sessions = []
         self.builtin_tools = {}
-        
-        # Set the agent_id directly instead of calling initialize()
-        self.agent_id = agent_id


### PR DESCRIPTION
- Changes to agent config following the refactor to use llama stack as the source of truth for agents instead of the database
- Posts to /mcp_servers/ now additionally registers tool groups to llama stack. Added a probably transient `/api/llama_stack/mcp_tools?toolgroup=mcp%3A%3Atoolgroup` endpoint to get tools by toolgroup.

