### PR TITLE
feat: LangGraph declarative graph engine with parallel execution and MCP integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,10 +57,15 @@ CONTAINER_RUNTIME=podman
 # ADMIN_USERNAME=admin
 # ADMIN_EMAIL=admin@example.com
 
-# Tavily Search API Key (optional, enables web search in AI agents)
-# Get your key from: https://tavily.com/
-# Leave empty or comment out to disable web search capabilities
+# Tavily Search API Key (optional, enables web search in AI agents and vacation planner)
+# Get your key from: https://tavily.com/ (free tier: 1,000 searches/month)
+# Used by: travel_research_mcp server
 # TAVILY_API_KEY=your_tavily_api_key_here
+
+# SerpApi API Key (optional, enables hotel and flight search in vacation planner)
+# Get your key from: https://serpapi.com/ (free tier: 100 searches/month)
+# Used by: hotel_mcp and flight_mcp servers
+# SERPAPI_API_KEY=your_serpapi_api_key_here
 
 # =============================================================================
 # Usage Instructions

--- a/backend/agent_templates/travel_vacation_planner.yaml
+++ b/backend/agent_templates/travel_vacation_planner.yaml
@@ -1,0 +1,80 @@
+name: "Travel Vacation Planner (LangGraph)"
+description: "Graph-based vacation planning agent using LangGraph declarative pipeline with MCP tool integration for research, hotels, and flights."
+category: "travel"
+templates:
+  vacation_planner:
+    name: "Vacation Planner"
+    persona: "vacation_planner"
+    runner_type: "langgraph"
+    prompt: "You are a vacation planning assistant that researches destinations, finds hotels, and searches flights to create comprehensive travel plans."
+    model_name: "meta-llama/Llama-3.1-8B-Instruct"
+    tools: []
+    knowledge_base_ids: []
+    demo_questions:
+      - "Plan a 5-day trip to Tokyo with a focus on culture and food"
+      - "Find me a beach vacation in Mexico for two adults next month"
+      - "Research a weekend getaway to Paris with hotel and flight options"
+    graph_config:
+      name: vacation_planner_langgraph
+      mcp:
+        transport: streamable-http
+        servers:
+          travel_research:
+            url: "${TRAVEL_RESEARCH_MCP_URL:http://localhost:7001/mcp}"
+          hotel:
+            url: "${HOTEL_MCP_URL:http://localhost:7002/mcp}"
+          flight:
+            url: "${FLIGHT_MCP_URL:http://localhost:7003/mcp}"
+      nodes:
+        - id: places_list_task
+          type: llm
+          prompt: |
+            List 5 specific places, neighborhoods, or attractions in {inputs.destination}
+            that match {inputs.interests}. Return a JSON array of strings only.
+
+        - id: destination_research_task
+          type: mcp_tool_map
+          server: travel_research
+          tool: tavily_travel_search
+          items_path: outputs.places_list_task
+          max_items: 5
+          query_template: "Research {item} in {inputs.destination} with highlights and must-see spots."
+          max_results: 5
+
+        - id: itinerary_options_task
+          type: llm
+          prompt: |
+            Create 2-3 itinerary options for the trip.
+            Include day-by-day highlights and note must-see places.
+
+        - id: hotel_research_task
+          type: mcp_tool
+          server: hotel
+          tool: google_hotels_search
+          args:
+            destination: "{inputs.destination}"
+            start_date: "{inputs.start_date}"
+            end_date: "{inputs.end_date}"
+            adults: 2
+            preferences: "{inputs.preferences}"
+
+        - id: flight_research_task
+          type: mcp_tool
+          server: flight
+          tool: google_flights_search
+          args:
+            origin: "{inputs.origin}"
+            destination: "{outputs.places_list_task}"
+            depart_date: "{inputs.start_date}"
+            return_date: "{inputs.end_date}"
+            passengers: 1
+            cabin: "{inputs.cabin}"
+
+      input_fields:
+        destination: "Tokyo"
+        interests: "culture and food"
+        origin: "New York"
+        start_date: "2026-04-01"
+        end_date: "2026-04-07"
+        preferences: "mid-range"
+        cabin: "economy"

--- a/backend/agent_templates/travel_vacation_planner.yaml
+++ b/backend/agent_templates/travel_vacation_planner.yaml
@@ -64,7 +64,7 @@ templates:
           tool: google_flights_search
           args:
             origin: "{inputs.origin}"
-            destination: "{outputs.places_list_task}"
+            destination: "{inputs.destination}"
             depart_date: "{inputs.start_date}"
             return_date: "{inputs.end_date}"
             passengers: 1

--- a/backend/agent_templates/travel_vacation_planner.yaml
+++ b/backend/agent_templates/travel_vacation_planner.yaml
@@ -43,6 +43,10 @@ templates:
 
         - id: itinerary_options_task
           type: llm
+          depends_on:
+            - destination_research_task
+            - hotel_research_task
+            - flight_research_task
           prompt: |
             Create 2-3 itinerary options for the trip.
             Include day-by-day highlights and note must-see places.

--- a/backend/app/api/v1/agent_templates.py
+++ b/backend/app/api/v1/agent_templates.py
@@ -332,10 +332,12 @@ async def initialize_agent_from_template(
 
         agent_config = VirtualAgentCreate(
             name=agent_name,
+            runner_type=template.runner_type or "llamastack",
             prompt=agent_prompt,
             model_name=model_to_use,
             tools=tools,
             knowledge_base_ids=kb_ids,
+            graph_config=template.graph_config,
             temperature=0.1,
             top_p=0.95,
             max_tokens=4096,

--- a/backend/app/api/v1/virtual_agents.py
+++ b/backend/app/api/v1/virtual_agents.py
@@ -73,6 +73,7 @@ async def create_virtual_agent_internal(
         "max_tokens": getattr(va, "max_tokens", None),
         "repetition_penalty": getattr(va, "repetition_penalty", None),
         "max_infer_iters": getattr(va, "max_infer_iters", None),
+        "graph_config": getattr(va, "graph_config", None),
     }
 
     # Create the agent
@@ -168,6 +169,7 @@ def config_to_response(config) -> VirtualAgentResponse:
         model_name=config.model_name,
         knowledge_base_ids=config.knowledge_base_ids or [],
         tools=tools,
+        graph_config=getattr(config, "graph_config", None),
         template_id=template_id,
         template_name=template_name,
         suite_id=suite_id,

--- a/backend/app/api/v1/virtual_agents.py
+++ b/backend/app/api/v1/virtual_agents.py
@@ -50,6 +50,7 @@ async def create_virtual_agent_internal(
     agent_data = {
         "id": agent_uuid,
         "name": va.name,
+        "runner_type": va.runner_type or "llamastack",
         "model_name": va.model_name,
         "template_id": va.template_id,
         "prompt": va.prompt,
@@ -160,6 +161,7 @@ def config_to_response(config) -> VirtualAgentResponse:
     return VirtualAgentResponse(
         id=config.id,
         name=config.name,
+        runner_type=config.runner_type or "llamastack",
         input_shields=config.input_shields or [],
         output_shields=config.output_shields or [],
         prompt=config.prompt,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -37,5 +37,14 @@ class Settings:
         os.getenv("AUTO_ASSIGN_AGENTS_TO_USERS", "true").lower() == "true"
     )
 
+    # LangGraph Runner Configuration
+    # Base URL for the OpenAI-compatible LLM API used by LangGraph agents.
+    # Falls back to LLAMA_STACK_URL/v1 if not set.
+    LANGGRAPH_LLM_API_BASE: Optional[str] = os.getenv("LANGGRAPH_LLM_API_BASE")
+    # API key for the LLM API. Use "no-key" for local servers that don't require auth.
+    LANGGRAPH_LLM_API_KEY: str = os.getenv("LANGGRAPH_LLM_API_KEY", "no-key")
+    # Override model name for LangGraph agents. If not set, uses the agent's model_name.
+    LANGGRAPH_DEFAULT_MODEL: Optional[str] = os.getenv("LANGGRAPH_DEFAULT_MODEL")
+
 
 settings = Settings()

--- a/backend/app/core/template_loader.py
+++ b/backend/app/core/template_loader.py
@@ -61,9 +61,11 @@ def convert_yaml_template_to_agent_template(
         persona=yaml_template["persona"],
         prompt=yaml_template["prompt"],
         model_name=yaml_template["model_name"],
-        tools=yaml_template["tools"],
-        knowledge_base_ids=yaml_template["knowledge_base_ids"],
+        runner_type=yaml_template.get("runner_type", "llamastack"),
+        tools=yaml_template.get("tools") or [],
+        knowledge_base_ids=yaml_template.get("knowledge_base_ids") or [],
         knowledge_base_config=yaml_template.get("knowledge_base_config"),
+        graph_config=yaml_template.get("graph_config"),
         demo_questions=yaml_template.get("demo_questions"),
     )
 

--- a/backend/app/core/template_startup.py
+++ b/backend/app/core/template_startup.py
@@ -2,7 +2,10 @@
 Template auto-population utility for startup.
 
 This module ensures that templates are automatically loaded from YAML files
-into the database when the backend starts, if they're not already there.
+into the database when the backend starts.  New suites and templates
+discovered in YAML that are not yet in the database are added
+incrementally so that adding a new YAML file does not require a
+database wipe.
 """
 
 import logging
@@ -20,83 +23,93 @@ logger = logging.getLogger(__name__)
 async def ensure_templates_populated():
     """
     Ensure templates are populated in the database from YAML files.
-    This runs at startup and only populates if tables are empty.
+    Performs an incremental sync: any suites or templates present in
+    YAML but missing from the database are inserted.
     """
     async with AsyncSessionLocal() as session:
         try:
-            # Check if templates already exist
-            result = await session.execute(select(TemplateSuite))
-            existing_suites = result.scalars().all()
-
-            if existing_suites:
-                logger.info(
-                    f"Templates already populated: {len(existing_suites)} suites found"
-                )
-                return
-
-            logger.info("🔄 Auto-populating templates from YAML files...")
-
             # Load templates from YAML files
             suites_data, templates_data = load_all_templates_from_directory()
             logger.info(
                 f"📁 Found {len(suites_data)} suites with "
-                f"{len(templates_data)} templates"
+                f"{len(templates_data)} templates in YAML"
             )
 
-            # Populate template_suites
+            # Build a lookup of existing suites by name
+            result = await session.execute(select(TemplateSuite))
+            existing_suites = {s.name: s for s in result.scalars().all()}
+
+            # Build a lookup of existing templates by name
+            result = await session.execute(select(AgentTemplate))
+            existing_templates = {t.name: t for t in result.scalars().all()}
+
+            suite_id_mapping = {}  # YAML suite key -> UUID (existing or new)
             suite_count = 0
-            suite_id_mapping = {}  # Map string IDs to UUIDs
-            for suite_id, suite_config in suites_data.items():
+            template_count = 0
+
+            # Sync suites
+            for suite_key, suite_config in suites_data.items():
+                suite_name = suite_config.get("name", suite_key)
+                if suite_name in existing_suites:
+                    suite_id_mapping[suite_key] = existing_suites[suite_name].id
+                    continue
+
                 suite_uuid = uuid.uuid4()
-                suite_id_mapping[suite_id] = suite_uuid
+                suite_id_mapping[suite_key] = suite_uuid
                 suite = TemplateSuite(
                     id=suite_uuid,
-                    name=suite_config.get("name", suite_id),
+                    name=suite_name,
                     category=suite_config.get("category", "uncategorized"),
                     description=suite_config.get(
-                        "description", f"Auto-imported suite: {suite_id}"
+                        "description", f"Auto-imported suite: {suite_key}"
                     ),
                     icon=suite_config.get("icon"),
                 )
                 session.add(suite)
                 suite_count += 1
-                logger.info(f"   ✅ Added suite: {suite_id} ({suite.name})")
+                logger.info(f"   ✅ Added suite: {suite_key} ({suite.name})")
 
-            # Populate agent_templates
-            template_count = 0
-            for template_id, template_config in templates_data.items():
+            # Sync templates
+            for template_key, template_config in templates_data.items():
+                template_name = getattr(template_config, "name", template_key)
+                if template_name in existing_templates:
+                    continue
+
                 # Find which suite this template belongs to
-                suite_id = None
-                for s_id, s_config in suites_data.items():
-                    if template_id in s_config.get("templates", {}):
-                        suite_id = s_id
+                suite_key = None
+                for s_key, s_config in suites_data.items():
+                    if template_key in s_config.get("templates", {}):
+                        suite_key = s_key
                         break
 
-                if not suite_id:
-                    logger.warning(f"Template '{template_id}' has no suite, skipping")
+                if not suite_key:
+                    logger.warning(f"Template '{template_key}' has no suite, skipping")
                     continue
 
                 template_uuid = uuid.uuid4()
-                suite_uuid = suite_id_mapping[suite_id]
+                suite_uuid = suite_id_mapping[suite_key]
                 template = AgentTemplate(
                     id=template_uuid,
                     suite_id=suite_uuid,
-                    name=getattr(template_config, "name", template_id),
-                    description=f"Auto-imported template: {template_id}",
+                    name=template_name,
+                    description=f"Auto-imported template: {template_key}",
                     config={},
                 )
                 session.add(template)
                 template_count += 1
                 logger.info(
-                    f"   ✅ Added template: {template_id} ({template.name}) -> "
-                    f"{suite_id}"
+                    f"   ✅ Added template: {template_key} ({template.name}) -> "
+                    f"{suite_key}"
                 )
 
-            await session.commit()
-            logger.info(
-                f"🎉 Successfully auto-populated {suite_count} suites and "
-                f"{template_count} templates!"
-            )
+            if suite_count or template_count:
+                await session.commit()
+                logger.info(
+                    f"🎉 Synced {suite_count} new suites and "
+                    f"{template_count} new templates!"
+                )
+            else:
+                logger.info("Templates already up-to-date, nothing to add")
 
         except Exception as e:
             await session.rollback()

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -48,6 +48,7 @@ class VirtualAgent(Base):
     max_tokens = Column(JSON, nullable=True)
     repetition_penalty = Column(JSON, nullable=True)
     max_infer_iters = Column(JSON, nullable=True)
+    graph_config = Column(JSON, nullable=True)
     created_at = Column(TIMESTAMP(timezone=True), server_default=func.now())
     updated_at = Column(
         TIMESTAMP(timezone=True),

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -30,6 +30,7 @@ class VirtualAgentBase(BaseModel):
     max_tokens: Optional[int] = None
     repetition_penalty: Optional[float] = None
     max_infer_iters: Optional[int] = 100
+    graph_config: Optional[Dict[str, Any]] = None
 
 
 class VirtualAgentCreate(VirtualAgentBase):
@@ -58,6 +59,7 @@ class VirtualAgentUpdate(BaseModel):
     max_tokens: Optional[int] = None
     repetition_penalty: Optional[float] = None
     max_infer_iters: Optional[int] = None
+    graph_config: Optional[Dict[str, Any]] = None
 
 
 class VirtualAgentInDB(VirtualAgentBase, TimestampMixin, BaseSchema):

--- a/backend/app/schemas/agent_templates.py
+++ b/backend/app/schemas/agent_templates.py
@@ -15,9 +15,11 @@ class AgentTemplate(BaseModel):
     persona: str
     prompt: str
     model_name: str
+    runner_type: str = "llamastack"
     tools: List[Dict[str, str]]
     knowledge_base_ids: List[str]
     knowledge_base_config: Optional[Dict] = None
+    graph_config: Optional[Dict] = None
     demo_questions: Optional[List[str]] = None
 
 

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -62,10 +62,11 @@ class ChatService:
         """
         if runner_type == "llamastack" or not runner_type:
             return LlamaStackRunner(self.request, self.db, self.user_id)
+        elif runner_type == "langgraph":
+            from .runners.langgraph_runner import LangGraphRunner
+
+            return LangGraphRunner(self.request, self.db, self.user_id)
         # Future runners will be added here:
-        # elif runner_type == "langgraph":
-        #     from .runners.langgraph_runner import LangGraphRunner
-        #     return LangGraphRunner(self.request, self.db, self.user_id)
         # elif runner_type == "crewai":
         #     from .runners.crewai_runner import CrewAIRunner
         #     return CrewAIRunner(self.request, self.db, self.user_id)

--- a/backend/app/services/runners/__init__.py
+++ b/backend/app/services/runners/__init__.py
@@ -7,9 +7,11 @@ agent framework (LlamaStack, LangGraph, CrewAI, etc.).
 """
 
 from .base import BaseRunner
+from .langgraph_runner import LangGraphRunner
 from .llamastack_runner import LlamaStackRunner
 
 __all__ = [
     "BaseRunner",
+    "LangGraphRunner",
     "LlamaStackRunner",
 ]

--- a/backend/app/services/runners/graph_engine.py
+++ b/backend/app/services/runners/graph_engine.py
@@ -1,0 +1,745 @@
+"""
+Declarative graph engine for LangGraph agents.
+
+Parses a graph config (YAML-style dict) and executes a DAG of typed nodes
+using LangGraph's StateGraph. Adapted from the vacation-planner POC with:
+
+  * Async execution throughout (httpx for MCP, ChatOpenAI for LLM)
+  * SSE event yielding compatible with the BaseRunner interface
+  * Reuse of the existing LLM configuration from LangGraphRunner
+
+Supported node types
+--------------------
+  llm          - Call the LLM with a rendered prompt template
+  mcp_tool     - Call a single MCP tool via JSON-RPC over HTTP
+  mcp_tool_map - Fan-out: call an MCP tool once per item from a prior node's output
+  router       - Conditional edge based on a prior node's output
+
+State flows between nodes via ``outputs[node_id] = result``.
+Templates use ``{inputs.field}`` and ``{outputs.node_id}`` for substitution.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, TypedDict
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Environment variable expansion  (${VAR:default})
+# ---------------------------------------------------------------------------
+
+_ENV_PATTERN = re.compile(r"\$\{([A-Z0-9_]+)(?::([^}]*))?\}")
+
+
+def _expand_env(value: Any) -> Any:
+    """Recursively expand ``${VAR:default}`` patterns in strings."""
+    if isinstance(value, str):
+
+        def _repl(m: re.Match) -> str:
+            var = m.group(1)
+            default = m.group(2) if m.group(2) is not None else ""
+            return os.getenv(var, default)
+
+        return _ENV_PATTERN.sub(_repl, value)
+    if isinstance(value, list):
+        return [_expand_env(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _expand_env(v) for k, v in value.items()}
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Template rendering helpers
+# ---------------------------------------------------------------------------
+
+
+class _DotDict(dict):
+    """Dict subclass allowing attribute access (returns '' for missing keys)."""
+
+    def __getattr__(self, name: str) -> Any:
+        return self.get(name, "")
+
+    def __getitem__(self, key: str) -> Any:
+        return self.get(key, "")
+
+
+def _render_template(value: Any, context: Dict[str, Any]) -> Any:
+    """Recursively render ``{inputs.x}`` / ``{outputs.y}`` in strings."""
+    if isinstance(value, str):
+        try:
+            return value.format_map(context)
+        except (KeyError, IndexError):
+            return value
+    if isinstance(value, list):
+        return [_render_template(v, context) for v in value]
+    if isinstance(value, dict):
+        return {k: _render_template(v, context) for k, v in value.items()}
+    return value
+
+
+def _get_path(data: Dict[str, Any], path: str) -> Any:
+    """Resolve a dot-separated path like ``outputs.places_list_task``."""
+    if not path:
+        return ""
+    parts = path.split(".")
+    cursor: Any = data
+    for part in parts:
+        if isinstance(cursor, dict) and part in cursor:
+            cursor = cursor[part]
+        else:
+            return ""
+    return cursor
+
+
+def _coerce_list(value: Any) -> List[str]:
+    """Coerce a value (JSON array string, CSV, newline-separated) to a list."""
+    if isinstance(value, list):
+        return [str(v).strip() for v in value if str(v).strip()]
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return []
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, list):
+                return [str(v).strip() for v in parsed if str(v).strip()]
+        except (json.JSONDecodeError, ValueError):
+            pass
+        if "\n" in raw:
+            return [
+                line.strip("- ").strip() for line in raw.splitlines() if line.strip()
+            ]
+        return [item.strip() for item in raw.split(",") if item.strip()]
+    if value is None:
+        return []
+    return [str(value).strip()]
+
+
+def _normalize_arg(value: Any) -> Any:
+    """Normalize string values to native Python types where possible."""
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.lower() in ("true", "false"):
+            return stripped.lower() == "true"
+        if re.fullmatch(r"-?\d+", stripped):
+            return int(stripped)
+        if re.fullmatch(r"-?\d+\.\d+", stripped):
+            return float(stripped)
+        return stripped
+    if isinstance(value, list):
+        return [_normalize_arg(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _normalize_arg(v) for k, v in value.items()}
+    return value
+
+
+def _sanitize_args(value: Any) -> Any:
+    """Normalize and drop empty/None values from arg dicts."""
+    normalized = _normalize_arg(value)
+    if isinstance(normalized, dict):
+        return {k: v for k, v in normalized.items() if v not in ("", None)}
+    return normalized
+
+
+# ---------------------------------------------------------------------------
+# MCP protocol helpers (async, using httpx)
+# ---------------------------------------------------------------------------
+
+_MCP_SESSIONS: Dict[str, str] = {}
+_TOOL_SCHEMAS: Dict[Tuple[str, str], Dict[str, Any]] = {}
+
+
+def _parse_mcp_result(payload: Any) -> str:
+    """Extract text from an MCP tools/call result payload."""
+    if isinstance(payload, str):
+        return payload
+    if isinstance(payload, dict):
+        content = payload.get("content")
+        if isinstance(content, list):
+            texts = [
+                item.get("text", "")
+                for item in content
+                if isinstance(item, dict) and item.get("type") == "text"
+            ]
+            joined = "\n".join([t for t in texts if t])
+            if joined:
+                return joined
+        for key in ("output", "result", "raw"):
+            if key in payload and isinstance(payload[key], str):
+                return payload[key]
+        return json.dumps(payload, indent=2)
+    return str(payload)
+
+
+def _parse_sse_json(text: str) -> Dict[str, Any]:
+    """Parse the last ``data:`` payload from an SSE text stream."""
+    data_payloads = []
+    for line in text.splitlines():
+        if line.startswith("data:"):
+            data = line[len("data:") :].strip()
+            if data:
+                data_payloads.append(data)
+    if not data_payloads:
+        raise ValueError("No JSON data found in SSE response")
+    return json.loads(data_payloads[-1])
+
+
+def _parse_mcp_response(response: httpx.Response) -> Dict[str, Any]:
+    """Parse an MCP response (JSON or SSE)."""
+    content_type = response.headers.get("content-type", "")
+    if "text/event-stream" in content_type:
+        return _parse_sse_json(response.text)
+    return response.json()
+
+
+def _extract_session_id(response: httpx.Response) -> str:
+    """Extract MCP session ID from response headers or JSON body."""
+    for key, value in response.headers.items():
+        if key.lower() == "mcp-session-id":
+            return value
+    try:
+        data = response.json()
+    except (ValueError, json.JSONDecodeError):
+        return ""
+    if isinstance(data, dict):
+        result = data.get("result") or {}
+        if isinstance(result, dict):
+            return str(result.get("sessionId") or "")
+    return ""
+
+
+async def _initialize_mcp_session(client: httpx.AsyncClient, url: str) -> str:
+    """Send MCP ``initialize`` JSON-RPC and return the session ID."""
+    logger.info("Initializing MCP session: %s", url)
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "clientInfo": {"name": "langgraph-graph-engine", "version": "1.0"},
+            "capabilities": {},
+        },
+    }
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+    }
+    try:
+        resp = await client.post(url, json=payload, headers=headers, timeout=30)
+        if resp.status_code >= 400:
+            logger.warning("MCP initialize failed %s: %s", resp.status_code, resp.text)
+            return ""
+        return _extract_session_id(resp)
+    except Exception as e:
+        logger.warning("MCP initialize error for %s: %s", url, e)
+        return ""
+
+
+async def _get_mcp_session(client: httpx.AsyncClient, url: str) -> str:
+    """Get or create an MCP session for the given URL."""
+    if url in _MCP_SESSIONS:
+        return _MCP_SESSIONS[url]
+    session_id = await _initialize_mcp_session(client, url)
+    if session_id:
+        _MCP_SESSIONS[url] = session_id
+        logger.info("MCP session established: %s", session_id)
+    return session_id
+
+
+async def _refresh_mcp_session(client: httpx.AsyncClient, url: str) -> str:
+    """Clear and re-initialize an MCP session."""
+    _MCP_SESSIONS.pop(url, None)
+    _TOOL_SCHEMAS.clear()
+    return await _get_mcp_session(client, url)
+
+
+async def _list_mcp_tools(client: httpx.AsyncClient, url: str) -> Dict[str, Any]:
+    """Discover available tools from an MCP server."""
+    session_id = await _get_mcp_session(client, url)
+    payload = {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+    }
+    if session_id:
+        headers["Mcp-Session-Id"] = session_id
+    try:
+        resp = await client.post(url, json=payload, headers=headers, timeout=30)
+        if resp.status_code >= 400:
+            logger.warning("tools/list failed %s: %s", resp.status_code, resp.text)
+            return {}
+        data = _parse_mcp_response(resp)
+        return data.get("result", {}) if isinstance(data, dict) else {}
+    except Exception as e:
+        logger.warning("tools/list error for %s: %s", url, e)
+        return {}
+
+
+async def _get_tool_input_schema(
+    client: httpx.AsyncClient, url: str, tool_name: str
+) -> Dict[str, Any]:
+    """Get the input schema for a specific MCP tool (cached)."""
+    key = (url, tool_name)
+    if key in _TOOL_SCHEMAS:
+        return _TOOL_SCHEMAS[key]
+    result = await _list_mcp_tools(client, url)
+    tools = result.get("tools", []) if isinstance(result, dict) else []
+    for tool in tools:
+        if isinstance(tool, dict) and tool.get("name") == tool_name:
+            schema = tool.get("inputSchema") or {}
+            if isinstance(schema, dict):
+                _TOOL_SCHEMAS[key] = schema
+                return schema
+    _TOOL_SCHEMAS[key] = {}
+    return {}
+
+
+async def _filter_args_to_schema(
+    client: httpx.AsyncClient,
+    url: str,
+    tool_name: str,
+    args: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Drop args not in the tool's input schema (prevents -32602 errors)."""
+    schema = await _get_tool_input_schema(client, url, tool_name)
+    props = schema.get("properties") if isinstance(schema, dict) else None
+    if not isinstance(props, dict) or not props:
+        return args
+    allowed = set(props.keys())
+    filtered = {k: v for k, v in args.items() if k in allowed}
+    dropped = sorted([k for k in args if k not in allowed])
+    if dropped:
+        logger.info("Filtered MCP args for %s (dropped: %s)", tool_name, dropped)
+    return filtered
+
+
+async def _call_mcp_tool(
+    client: httpx.AsyncClient,
+    url: str,
+    tool_name: str,
+    arguments: Dict[str, Any],
+) -> str:
+    """Call an MCP tool via JSON-RPC over HTTP."""
+    if not url:
+        return "MCP server URL is missing."
+
+    logger.info("MCP tool call: %s -> %s args=%s", url, tool_name, arguments)
+
+    session_id = await _get_mcp_session(client, url)
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/call",
+        "params": {"name": tool_name, "arguments": arguments},
+    }
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+    }
+    if session_id:
+        headers["Mcp-Session-Id"] = session_id
+
+    try:
+        resp = await client.post(url, json=payload, headers=headers, timeout=60)
+
+        if resp.status_code == 400 and "session id" in resp.text.lower():
+            logger.warning("MCP session invalid, refreshing: %s", url)
+            session_id = await _refresh_mcp_session(client, url)
+            if session_id:
+                headers["Mcp-Session-Id"] = session_id
+            resp = await client.post(url, json=payload, headers=headers, timeout=60)
+
+        if resp.status_code >= 400:
+            logger.warning("MCP tool call failed %s: %s", resp.status_code, resp.text)
+            return f"MCP error {resp.status_code}: {resp.text}"
+
+        data = _parse_mcp_response(resp)
+        if isinstance(data, dict) and "error" in data:
+            logger.error("MCP tool error: %s", data["error"])
+            return f"MCP tool error: {data['error']}"
+
+        if isinstance(data, dict):
+            return _parse_mcp_result(data.get("result", ""))
+        return _parse_mcp_result(data)
+
+    except Exception as e:
+        logger.exception("MCP tool call exception for %s: %s", tool_name, e)
+        return f"MCP call error: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Graph state
+# ---------------------------------------------------------------------------
+
+
+class GraphState(TypedDict, total=False):
+    """State passed between nodes in the declarative graph."""
+
+    inputs: Dict[str, Any]
+    outputs: Dict[str, str]
+    tasks_output: List[Dict[str, Any]]
+
+
+# ---------------------------------------------------------------------------
+# Graph engine
+# ---------------------------------------------------------------------------
+
+
+class GraphEngine:
+    """
+    Builds and executes a declarative LangGraph agent from a config dict.
+
+    Parameters
+    ----------
+    config : dict
+        The graph configuration (same schema as graph.yaml).
+    llm : ChatOpenAI
+        Pre-configured LLM instance from LangGraphRunner.
+    """
+
+    def __init__(self, config: Dict[str, Any], llm: Any) -> None:
+        cfg = _expand_env(config)
+        self.mcp_cfg = cfg.get("mcp") or {}
+        self.llm = llm
+        nodes = cfg.get("nodes") or cfg.get("steps") or []
+        if not isinstance(nodes, list) or not nodes:
+            raise ValueError("Graph config must define a non-empty 'nodes' list")
+        self.nodes = nodes
+        self.edges = cfg.get("edges") or []
+        self.entry_id: Optional[str] = cfg.get("entry")
+
+    def _build_graph(self):
+        """Build a compiled LangGraph StateGraph from the config."""
+        from langgraph.graph import END, StateGraph
+
+        graph = StateGraph(GraphState)
+        previous = None
+        node_defs: Dict[str, dict] = {}
+
+        for step in self.nodes:
+            if not isinstance(step, dict) or "id" not in step:
+                raise ValueError("Each node must be a mapping with an 'id'")
+            step_id = str(step["id"])
+            node_defs[step_id] = step
+            graph.add_node(step_id, self._make_step_fn(step))
+            if not self.entry_id and step.get("entry"):
+                self.entry_id = step_id
+            if not self.edges:
+                if previous:
+                    graph.add_edge(previous, step_id)
+                else:
+                    graph.set_entry_point(step_id)
+                previous = step_id
+
+        if self.edges:
+            if not isinstance(self.edges, list):
+                raise ValueError("'edges' must be a list")
+            for edge in self.edges:
+                if not isinstance(edge, dict):
+                    raise ValueError("Each edge must be a mapping")
+                src = str(edge.get("from", "")).strip()
+                dst = str(edge.get("to", "")).strip()
+                if not src or not dst:
+                    raise ValueError("Each edge must define 'from' and 'to'")
+                src_def = node_defs.get(src, {})
+                if str(src_def.get("type", "")).strip().lower() == "router":
+                    continue
+                graph.add_edge(src, dst)
+        elif previous:
+            graph.add_edge(previous, END)
+
+        if self.edges:
+            for step_id, step in node_defs.items():
+                if str(step.get("type", "")).strip().lower() != "router":
+                    continue
+                router = self._build_router(step)
+                routes = router["routes"]
+                graph.add_conditional_edges(step_id, router["fn"], routes)
+
+        entry_id = self.entry_id or (self.nodes[0]["id"] if self.nodes else None)
+        if entry_id:
+            graph.set_entry_point(str(entry_id))
+        return graph.compile()
+
+    @staticmethod
+    def _build_router(step: dict) -> Dict[str, Any]:
+        """Build a conditional routing function for a router node."""
+        route_on = str(step.get("route_on", "")).strip()
+        routes = step.get("routes") or {}
+        if not route_on or not isinstance(routes, dict):
+            raise ValueError("Router node requires 'route_on' and 'routes' mapping")
+
+        def _route(state: GraphState) -> str:
+            inputs = state.get("inputs") or {}
+            outputs = state.get("outputs") or {}
+            value = _get_path({"inputs": inputs, "outputs": outputs}, route_on)
+            value_str = str(value)
+            if value_str in routes:
+                return str(routes[value_str])
+            return str(routes.get("default", ""))
+
+        return {"fn": _route, "routes": routes}
+
+    def _make_step_fn(self, step: dict):
+        """Create a node function for the given step config."""
+        step_id = str(step["id"])
+        step_type = str(step.get("type", "")).strip().lower()
+        mcp_servers = self.mcp_cfg.get("servers") or {}
+        mcp_transport = str(self.mcp_cfg.get("transport") or "streamable-http").lower()
+        llm = self.llm
+
+        async def _run(state: GraphState) -> GraphState:
+            inputs = state.get("inputs") or {}
+            outputs = state.setdefault("outputs", {})
+            tasks_output = state.setdefault("tasks_output", [])
+
+            logger.info("Graph node started: %s (%s)", step_id, step_type)
+
+            result = ""
+
+            if step_type in ("llm", "prompt"):
+                result = await _run_llm_node(llm, step, inputs, outputs)
+
+            elif step_type in ("mcp_tool", "mcp"):
+                result = await _run_mcp_tool_node(
+                    step, inputs, outputs, mcp_servers, mcp_transport
+                )
+
+            elif step_type in ("mcp_tool_map", "mcp_map"):
+                result = await _run_mcp_tool_map_node(
+                    step, inputs, outputs, mcp_servers, mcp_transport
+                )
+
+            elif step_type == "router":
+                result = "Router node evaluated."
+
+            else:
+                result = f"Unsupported node type: {step_type}"
+
+            outputs[step_id] = result
+            tasks_output.append(
+                {
+                    "name": step_id,
+                    "summary": _summarize_output(result),
+                    "raw": result,
+                }
+            )
+            logger.info("Graph node completed: %s", step_id)
+            return state
+
+        return _run
+
+    async def run_streaming(
+        self,
+        inputs: Dict[str, Any],
+        session_id: str,
+    ) -> AsyncIterator[str]:
+        """
+        Execute the graph and yield SSE events for each node.
+
+        Yields ``node_started``, ``node_completed``, and a final
+        ``response`` event with the concatenated output.
+        """
+        graph = self._build_graph()
+        state: GraphState = {
+            "inputs": inputs,
+            "outputs": {},
+            "tasks_output": [],
+        }
+
+        result_state = await graph.ainvoke(state)
+
+        tasks_output = result_state.get("tasks_output", [])
+
+        for task in tasks_output:
+            node_name = task.get("name", "unknown")
+            yield _sse("node_started", {"node": node_name}, session_id)
+            raw = task.get("raw", "")
+            if raw:
+                yield _sse(
+                    "response",
+                    {"delta": raw, "status": "in_progress", "id": node_name},
+                    session_id,
+                )
+            yield _sse("node_completed", {"node": node_name}, session_id)
+
+        final_output = ""
+        if tasks_output:
+            last_task = tasks_output[-1]
+            final_output = last_task.get("raw", "")
+
+        if final_output:
+            yield _sse(
+                "response",
+                {"delta": "", "status": "completed", "id": "graph_final"},
+                session_id,
+            )
+        else:
+            yield _sse(
+                "error",
+                {"message": "Graph produced no output."},
+                session_id,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Node execution functions
+# ---------------------------------------------------------------------------
+
+
+async def _run_llm_node(
+    llm: Any,
+    step: dict,
+    inputs: Dict[str, Any],
+    outputs: Dict[str, Any],
+) -> str:
+    """Execute an LLM node: render the prompt and call the model."""
+    prompt_template = step.get("prompt", "Provide a response.")
+    context = {
+        "inputs": _DotDict(inputs),
+        "outputs": _DotDict(outputs),
+    }
+    rendered_prompt = _render_template(str(prompt_template), context)
+
+    content = (
+        f"{rendered_prompt}\n\n"
+        f"Inputs:\n{json.dumps(inputs, indent=2)}\n\n"
+        f"Outputs so far:\n{json.dumps(outputs, indent=2)}\n"
+    )
+
+    try:
+        response = await llm.ainvoke([{"role": "user", "content": content}])
+        return response.content if hasattr(response, "content") else str(response)
+    except Exception as e:
+        logger.exception("LLM node error: %s", e)
+        return f"LLM error: {e}"
+
+
+async def _run_mcp_tool_node(
+    step: dict,
+    inputs: Dict[str, Any],
+    outputs: Dict[str, Any],
+    mcp_servers: Dict[str, Any],
+    mcp_transport: str,
+) -> str:
+    """Execute an MCP tool node: call a single tool with rendered args."""
+    server_name = step.get("server", "")
+    tool_name = step.get("tool", "")
+    server_cfg = mcp_servers.get(server_name, {}) if server_name else {}
+    url = str(server_cfg.get("url", "")).strip()
+    transport = str(server_cfg.get("transport", mcp_transport)).lower()
+
+    if transport not in ("streamable-http", "http", "streamable"):
+        return f"Unsupported MCP transport: {transport}"
+    if not tool_name:
+        return "Missing tool name for MCP node."
+
+    context = {"inputs": _DotDict(inputs), "outputs": _DotDict(outputs)}
+    raw_args = step.get("args") or {}
+    args = _render_template(raw_args, context)
+
+    if isinstance(args, dict):
+        for key, value in list(args.items()):
+            if value in ("", None) and key in inputs:
+                args[key] = inputs.get(key)
+
+    args = _sanitize_args(args)
+
+    async with httpx.AsyncClient() as client:
+        if isinstance(args, dict):
+            args = await _filter_args_to_schema(client, url, str(tool_name), args)
+        return await _call_mcp_tool(
+            client, url, str(tool_name), args if isinstance(args, dict) else {}
+        )
+
+
+async def _run_mcp_tool_map_node(
+    step: dict,
+    inputs: Dict[str, Any],
+    outputs: Dict[str, Any],
+    mcp_servers: Dict[str, Any],
+    mcp_transport: str,
+) -> str:
+    """Execute an MCP tool map node: fan-out over a list of items."""
+    server_name = step.get("server", "")
+    tool_name = step.get("tool", "")
+    server_cfg = mcp_servers.get(server_name, {}) if server_name else {}
+    url = str(server_cfg.get("url", "")).strip()
+    transport = str(server_cfg.get("transport", mcp_transport)).lower()
+
+    if transport not in ("streamable-http", "http", "streamable"):
+        return f"Unsupported MCP transport: {transport}"
+    if not tool_name:
+        return "Missing tool name for MCP map node."
+
+    items_path = str(step.get("items_path", "")).strip()
+    items_value = _get_path({"inputs": inputs, "outputs": outputs}, items_path)
+    items = _coerce_list(items_value)
+    max_items = int(step.get("max_items", 5) or 5)
+    items = items[:max_items]
+
+    if not items:
+        return "No items to iterate for MCP map node."
+
+    results = []
+    async with httpx.AsyncClient() as client:
+        for idx, item in enumerate(items, start=1):
+            context = {
+                "inputs": _DotDict(inputs),
+                "outputs": _DotDict(outputs),
+                "item": item,
+                "item_index": idx,
+            }
+            query_template = step.get("query_template")
+            if query_template:
+                raw_args = {
+                    "query": query_template,
+                    "max_results": step.get("max_results", 5),
+                }
+            else:
+                raw_args = step.get("args") or {}
+
+            args = _render_template(raw_args, context)
+            if isinstance(args, dict):
+                for key, value in list(args.items()):
+                    if value in ("", None) and key in inputs:
+                        args[key] = inputs.get(key)
+            args = _sanitize_args(args)
+            if isinstance(args, dict):
+                args = await _filter_args_to_schema(client, url, str(tool_name), args)
+            item_result = await _call_mcp_tool(
+                client,
+                url,
+                str(tool_name),
+                args if isinstance(args, dict) else {},
+            )
+            results.append(f"#{idx} {item}\n{item_result}")
+
+    return "\n\n".join(results)
+
+
+# ---------------------------------------------------------------------------
+# SSE / summary helpers
+# ---------------------------------------------------------------------------
+
+
+def _sse(event_type: str, data: dict, session_id: str) -> str:
+    """Create an SSE-formatted event string."""
+    payload = {"type": event_type, "session_id": str(session_id), **data}
+    return f"data: {json.dumps(payload)}\n\n"
+
+
+def _summarize_output(text: str) -> str:
+    """One-line summary of a node's output."""
+    if not text:
+        return "No output"
+    first_line = text.splitlines()[0].strip()
+    return first_line if first_line else "Output generated"

--- a/backend/app/services/runners/langgraph_runner.py
+++ b/backend/app/services/runners/langgraph_runner.py
@@ -1,0 +1,497 @@
+"""
+LangGraph runner implementation.
+
+Uses LangGraph's create_react_agent for ReAct-style agent execution
+with streaming support, MCP tool integration, and session persistence
+via an in-memory checkpointer (thread_id = session_id).
+
+SSE event mapping
+-----------------
+LangGraph stream modes -> our normalized events:
+
+  "messages" mode  (token-level)
+    AIMessageChunk.content          -> response  {delta, status}
+  "updates" mode   (node-level)
+    agent node with tool_calls      -> tool_call {status: in_progress}
+    tools node with ToolMessage     -> tool_call {status: completed}
+    any node start                  -> node_started {node}
+    any node end                    -> node_completed {node}
+
+The stream ends with ``data: [DONE]\\n\\n``.
+"""
+
+import json
+import logging
+import uuid
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+from fastapi.encoders import jsonable_encoder
+from sqlalchemy import select
+
+from ...config import settings
+from ...models import ChatSession
+from .base import BaseRunner
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Optional LangGraph imports (module-level for patchability in tests)
+# ---------------------------------------------------------------------------
+
+try:
+    from langchain_core.messages import AIMessageChunk
+    from langchain_openai import ChatOpenAI
+    from langgraph.checkpoint.memory import InMemorySaver
+    from langgraph.prebuilt import create_react_agent
+
+    _LANGGRAPH_AVAILABLE = True
+except ImportError:
+    AIMessageChunk = None  # type: ignore[assignment,misc]
+    ChatOpenAI = None  # type: ignore[assignment,misc]
+    InMemorySaver = None  # type: ignore[assignment,misc]
+    create_react_agent = None  # type: ignore[assignment]
+    _LANGGRAPH_AVAILABLE = False
+
+
+def _check_langgraph() -> bool:
+    """Return True if langgraph and its dependencies are importable."""
+    return _LANGGRAPH_AVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# Shared checkpointer (module-level singleton)
+# ---------------------------------------------------------------------------
+# InMemorySaver is sufficient for single-process development.
+# For production / multi-worker deployments swap with PostgresSaver or
+# another durable checkpointer backed by the application database.
+
+_checkpointer = None
+
+
+def _get_checkpointer():
+    global _checkpointer
+    if _checkpointer is None:
+        _checkpointer = InMemorySaver()
+    return _checkpointer
+
+
+# ---------------------------------------------------------------------------
+# LangGraph Runner
+# ---------------------------------------------------------------------------
+
+
+class LangGraphRunner(BaseRunner):
+    """
+    Runner for LangGraph agents using the prebuilt ReAct agent pattern.
+
+    Features
+    --------
+    * **Token-level streaming** via ``astream(stream_mode=["messages","updates"])``
+    * **MCP tools** loaded at runtime through ``langchain-mcp-adapters``
+    * **Session persistence** via LangGraph's checkpointer (``thread_id = session_id``)
+    * **Normalized SSE events** compatible with the frontend (response, tool_call,
+      node_started, node_completed, error)
+    """
+
+    # ----- LLM setup -------------------------------------------------------
+
+    def _create_llm(self, agent: Any):
+        """
+        Create a ``ChatOpenAI`` instance for the given agent.
+
+        Resolution order for base_url:
+        1. ``LANGGRAPH_LLM_API_BASE`` env / config
+        2. ``LLAMA_STACK_URL`` + ``/v1``  (OpenAI compat layer)
+        """
+        base_url = settings.LANGGRAPH_LLM_API_BASE
+        if not base_url and settings.LLAMA_STACK_URL:
+            base_url = f"{settings.LLAMA_STACK_URL}/v1"
+
+        model_name = agent.model_name or settings.LANGGRAPH_DEFAULT_MODEL
+
+        return ChatOpenAI(
+            model=model_name,
+            base_url=base_url,
+            api_key=settings.LANGGRAPH_LLM_API_KEY,
+            temperature=agent.temperature or 0,
+            streaming=True,
+        )
+
+    # ----- MCP tool resolution ----------------------------------------------
+
+    async def _resolve_mcp_servers(
+        self,
+        tools: Optional[List],
+    ) -> Dict[str, dict]:
+        """
+        Resolve MCP server URLs from the agent's tool config.
+
+        Uses the LlamaStack toolgroups API (same source as LlamaStackRunner)
+        and returns a mapping suitable for ``MultiServerMCPClient``::
+
+            {"server_label": {"url": "http://…", "transport": "streamable_http"}}
+        """
+        if not tools:
+            return {}
+
+        mcp_configs: Dict[str, dict] = {}
+
+        for tool_info in tools:
+            tool_id = tool_info.get("toolgroup_id", "")
+            if not tool_id.startswith("mcp::"):
+                continue
+
+            try:
+                from ...api.llamastack import get_client_from_request
+
+                client = get_client_from_request(self.request)
+                toolgroups = await client.toolgroups.list()
+
+                for toolgroup in toolgroups:
+                    if str(toolgroup.identifier) == tool_id:
+                        label = toolgroup.args.get("name", str(toolgroup.identifier))
+                        url = toolgroup.mcp_endpoint.uri
+                        mcp_configs[label] = {
+                            "url": url,
+                            "transport": "streamable_http",
+                        }
+                        logger.info(f"Resolved MCP server '{label}' at {url}")
+                        break
+            except Exception as e:
+                logger.warning(f"Failed to resolve MCP server for {tool_id}: {e}")
+
+        return mcp_configs
+
+    # ----- Input conversion -------------------------------------------------
+
+    @staticmethod
+    def _build_input_messages(prompt: Any) -> list:
+        """Convert the prompt (content items list) to LangGraph input format."""
+        text_parts: list[str] = []
+
+        if isinstance(prompt, list):
+            for item in prompt:
+                if hasattr(item, "text") and item.text:
+                    text_parts.append(item.text)
+                elif isinstance(item, dict) and item.get("text"):
+                    text_parts.append(item["text"])
+        elif isinstance(prompt, str):
+            text_parts.append(prompt)
+        elif hasattr(prompt, "text"):
+            text_parts.append(prompt.text)
+
+        user_text = "\n".join(text_parts) if text_parts else str(prompt)
+        return [{"role": "user", "content": user_text}]
+
+    # ----- SSE helpers -------------------------------------------------------
+
+    @staticmethod
+    def _sse(event_type: str, data: dict, session_id: str) -> str:
+        """Create an SSE-formatted event string."""
+        payload = {"type": event_type, "session_id": str(session_id), **data}
+        return f"data: {json.dumps(payload)}\n\n"
+
+    @staticmethod
+    def _message_to_dict(msg: Any) -> dict:
+        """Normalise a LangChain message object to a plain dict."""
+        if hasattr(msg, "model_dump"):
+            return msg.model_dump()
+        if hasattr(msg, "dict"):
+            return msg.dict()
+        result: dict = {
+            "type": getattr(msg, "type", "unknown"),
+            "content": getattr(msg, "content", ""),
+        }
+        if hasattr(msg, "tool_calls") and msg.tool_calls:
+            result["tool_calls"] = [
+                {
+                    "id": (
+                        tc.get("id", "")
+                        if isinstance(tc, dict)
+                        else getattr(tc, "id", "")
+                    ),
+                    "name": (
+                        tc.get("name", "")
+                        if isinstance(tc, dict)
+                        else getattr(tc, "name", "")
+                    ),
+                    "args": (
+                        tc.get("args", {})
+                        if isinstance(tc, dict)
+                        else getattr(tc, "args", {})
+                    ),
+                }
+                for tc in msg.tool_calls
+            ]
+        if hasattr(msg, "tool_call_id"):
+            result["tool_call_id"] = msg.tool_call_id
+        if hasattr(msg, "name"):
+            result["name"] = msg.name
+        return result
+
+    # ----- Core graph execution ---------------------------------------------
+
+    async def _run_graph(
+        self,
+        agent: Any,
+        tools: list,
+        session_id: str,
+        prompt: Any,
+    ) -> AsyncIterator[str]:
+        """Build a ReAct agent graph, stream it, and yield SSE events."""
+        llm = self._create_llm(agent)
+        checkpointer = _get_checkpointer()
+
+        graph = create_react_agent(
+            model=llm,
+            tools=tools,
+            prompt=agent.prompt or "You are a helpful assistant.",
+            checkpointer=checkpointer,
+        )
+
+        input_messages = self._build_input_messages(prompt)
+
+        max_iters = getattr(agent, "max_infer_iters", None) or 100
+        config = {
+            "configurable": {"thread_id": str(session_id)},
+            "recursion_limit": 2 * max_iters + 1,
+        }
+
+        # State tracking across the interleaved stream
+        response_id = str(uuid.uuid4())[:8]
+        has_output_text = False
+        pending_tool_calls: Dict[str, dict] = {}
+
+        try:
+            async for mode, chunk in graph.astream(
+                {"messages": input_messages},
+                config=config,
+                stream_mode=["messages", "updates"],
+            ):
+                # -- Token-level streaming (messages mode) -------------------
+                if mode == "messages":
+                    msg_chunk, metadata = chunk
+                    node = metadata.get("langgraph_node", "")
+
+                    if isinstance(msg_chunk, AIMessageChunk) and node == "agent":
+                        content = msg_chunk.content
+                        if content and isinstance(content, str):
+                            has_output_text = True
+                            yield self._sse(
+                                "response",
+                                {
+                                    "delta": content,
+                                    "status": "in_progress",
+                                    "id": response_id,
+                                },
+                                session_id,
+                            )
+
+                # -- Node-level updates (updates mode) -----------------------
+                elif mode == "updates":
+                    for node_name, node_output in chunk.items():
+                        if node_name == "__end__":
+                            continue
+
+                        yield self._sse("node_started", {"node": node_name}, session_id)
+
+                        messages = node_output.get("messages", [])
+                        for msg in messages:
+                            msg_dict = self._message_to_dict(msg)
+
+                            # Agent decided to call tool(s)
+                            if node_name == "agent" and msg_dict.get("tool_calls"):
+                                for tc in msg_dict["tool_calls"]:
+                                    tc_id = tc.get("id", str(uuid.uuid4()))
+                                    pending_tool_calls[tc_id] = tc
+                                    yield self._sse(
+                                        "tool_call",
+                                        {
+                                            "id": tc_id,
+                                            "name": tc.get("name", "unknown"),
+                                            "server_label": "langgraph",
+                                            "arguments": json.dumps(tc.get("args", {})),
+                                            "output": None,
+                                            "error": None,
+                                            "status": "in_progress",
+                                        },
+                                        session_id,
+                                    )
+
+                            # Tool execution completed
+                            if node_name == "tools" and msg_dict.get("type") == "tool":
+                                tc_id = msg_dict.get("tool_call_id", "")
+                                tool_name = msg_dict.get("name", "unknown")
+                                output = msg_dict.get("content", "")
+                                error = None
+
+                                if msg_dict.get("status") == "error":
+                                    error = output
+                                    output = None
+
+                                orig = pending_tool_calls.get(tc_id, {})
+                                yield self._sse(
+                                    "tool_call",
+                                    {
+                                        "id": tc_id,
+                                        "name": tool_name,
+                                        "server_label": "langgraph",
+                                        "arguments": (
+                                            json.dumps(orig.get("args", {}))
+                                            if orig
+                                            else None
+                                        ),
+                                        "output": output,
+                                        "error": error,
+                                        "status": ("failed" if error else "completed"),
+                                    },
+                                    session_id,
+                                )
+
+                        yield self._sse(
+                            "node_completed",
+                            {"node": node_name},
+                            session_id,
+                        )
+
+            # Mark response complete (only if we emitted text)
+            if has_output_text:
+                yield self._sse(
+                    "response",
+                    {"delta": "", "status": "completed", "id": response_id},
+                    session_id,
+                )
+            elif not pending_tool_calls:
+                yield self._sse(
+                    "error",
+                    {
+                        "message": (
+                            "The assistant couldn't generate a text response. "
+                            "Please try again or rephrase your request."
+                        )
+                    },
+                    session_id,
+                )
+
+        except Exception as e:
+            logger.exception(f"Error during LangGraph execution: {e}")
+            yield self._sse(
+                "error",
+                {"message": f"LangGraph execution error: {str(e)}"},
+                session_id,
+            )
+
+    # ----- Public interface (BaseRunner) ------------------------------------
+
+    async def stream(
+        self,
+        agent: Any,
+        session_id: str,
+        prompt: Any,
+    ) -> AsyncIterator[str]:
+        """
+        Stream a response using LangGraph's ReAct agent.
+
+        Yields SSE-formatted strings with normalised event types.
+        """
+        if not _check_langgraph():
+            error_data = {
+                "type": "error",
+                "message": (
+                    "LangGraph is not installed. "
+                    "Install langgraph and langchain-openai to use this runner."
+                ),
+                "session_id": str(session_id),
+            }
+            yield f"data: {json.dumps(error_data)}\n\n"
+            yield "data: [DONE]\n\n"
+            return
+
+        try:
+            # Resolve MCP tools from agent config
+            mcp_configs = await self._resolve_mcp_servers(agent.tools)
+            tools: list = []
+
+            if mcp_configs:
+                try:
+                    from langchain_mcp_adapters.client import (
+                        MultiServerMCPClient,
+                    )
+
+                    async with MultiServerMCPClient(mcp_configs) as mcp_client:
+                        tools = mcp_client.get_tools()
+                        logger.info(
+                            f"Loaded {len(tools)} MCP tools "
+                            f"for LangGraph agent {agent.id}"
+                        )
+                        async for event in self._run_graph(
+                            agent, tools, session_id, prompt
+                        ):
+                            yield event
+                except ImportError:
+                    logger.warning(
+                        "langchain-mcp-adapters not installed; "
+                        "running LangGraph agent without MCP tools"
+                    )
+                    async for event in self._run_graph(agent, [], session_id, prompt):
+                        yield event
+                except Exception as mcp_err:
+                    logger.warning(
+                        f"MCP tool loading failed ({mcp_err}); "
+                        f"running agent without tools"
+                    )
+                    async for event in self._run_graph(agent, [], session_id, prompt):
+                        yield event
+            else:
+                async for event in self._run_graph(agent, [], session_id, prompt):
+                    yield event
+
+            yield "data: [DONE]\n\n"
+
+            # Best-effort session title update
+            await self._update_session_title(session_id, prompt)
+
+        except Exception as e:
+            logger.exception(f"Error in LangGraph stream for agent {agent.id}: {e}")
+            error_data = {
+                "type": "error",
+                "message": f"Error: {str(e)}",
+                "session_id": str(session_id),
+            }
+            yield f"data: {json.dumps(jsonable_encoder(error_data))}\n\n"
+
+    # ----- Session helpers --------------------------------------------------
+
+    async def _update_session_title(self, session_id: str, user_input: Any) -> None:
+        """Update session title from the first user message (best-effort)."""
+        result = await self.db.execute(
+            select(ChatSession)
+            .where(ChatSession.id == session_id)
+            .where(ChatSession.user_id == self.user_id)
+        )
+        session = result.scalar_one_or_none()
+
+        if not session:
+            return
+
+        if session.title and not session.title.startswith("Chat"):
+            return
+
+        title = "New Chat"
+        if isinstance(user_input, list) and user_input:
+            for item in user_input:
+                if hasattr(item, "text") and item.text:
+                    txt = item.text
+                    title = txt[:50] + ("..." if len(txt) > 50 else "")
+                    break
+        elif hasattr(user_input, "text"):
+            txt = user_input.text
+            title = txt[:50] + ("..." if len(txt) > 50 else "")
+
+        session.title = title
+
+        try:
+            await self.db.commit()
+        except Exception as e:
+            logger.error(f"Error updating session title: {e}")
+            await self.db.rollback()

--- a/backend/migrations/versions/c3a7f2e1b456_add_graph_config_to_virtual_agents.py
+++ b/backend/migrations/versions/c3a7f2e1b456_add_graph_config_to_virtual_agents.py
@@ -1,0 +1,31 @@
+"""add_graph_config_to_virtual_agents
+
+Revision ID: c3a7f2e1b456
+Revises: ba58d1b9cea2
+Create Date: 2026-02-17 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c3a7f2e1b456"
+down_revision: Union[str, None] = "ba58d1b9cea2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add graph_config JSON column for declarative graph agents."""
+    op.add_column(
+        "virtual_agents",
+        sa.Column("graph_config", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove graph_config column."""
+    op.drop_column("virtual_agents", "graph_config")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,3 +23,7 @@ boto3
 python-multipart
 python-magic
 pyyaml
+# LangGraph runner
+langgraph
+langchain-openai
+langchain-mcp-adapters

--- a/deploy/local/compose.yaml
+++ b/deploy/local/compose.yaml
@@ -176,7 +176,7 @@ services:
     networks:
       - ai-va-network
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:7001/mcp')\" || exit 1"]
+      test: ["CMD-SHELL", "python -c \"import socket; s=socket.create_connection(('localhost',7001),2); s.close()\""]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -197,7 +197,7 @@ services:
     networks:
       - ai-va-network
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:7002/mcp')\" || exit 1"]
+      test: ["CMD-SHELL", "python -c \"import socket; s=socket.create_connection(('localhost',7002),2); s.close()\""]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -218,7 +218,7 @@ services:
     networks:
       - ai-va-network
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:7003/mcp')\" || exit 1"]
+      test: ["CMD-SHELL", "python -c \"import socket; s=socket.create_connection(('localhost',7003),2); s.close()\""]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/deploy/local/compose.yaml
+++ b/deploy/local/compose.yaml
@@ -106,6 +106,10 @@ services:
       - LANGGRAPH_LLM_API_BASE=http://llamastack:8321/v1
       - LANGGRAPH_LLM_API_KEY=no-key
       - LANGGRAPH_DEFAULT_MODEL=${LANGGRAPH_DEFAULT_MODEL:-ollama/llama3.2:1b-instruct-fp16}
+      # MCP server URLs for vacation planner graph
+      - TRAVEL_RESEARCH_MCP_URL=http://travel-research-mcp:7001/mcp
+      - HOTEL_MCP_URL=http://hotel-mcp:7002/mcp
+      - FLIGHT_MCP_URL=http://flight-mcp:7003/mcp
     ports:
       - '${BACKEND_PORT:-8000}:8000'
     volumes:
@@ -152,6 +156,70 @@ services:
       timeout: 10s
       retries: 3
       start_period: 15s
+
+  # MCP servers for vacation planner graph agent
+  travel-research-mcp:
+    build:
+      context: ../../mcp_servers/travel_research_mcp
+      dockerfile: Containerfile
+    container_name: travel-research-mcp-dev
+    restart: unless-stopped
+    environment:
+      - TAVILY_API_KEY=${TAVILY_API_KEY:-}
+      - HOST=0.0.0.0
+      - PORT=7001
+    ports:
+      - '7001:7001'
+    networks:
+      - ai-va-network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:7001/mcp || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  hotel-mcp:
+    build:
+      context: ../../mcp_servers/hotel_mcp
+      dockerfile: Containerfile
+    container_name: hotel-mcp-dev
+    restart: unless-stopped
+    environment:
+      - SERPAPI_API_KEY=${SERPAPI_API_KEY:-}
+      - HOST=0.0.0.0
+      - PORT=7002
+    ports:
+      - '7002:7002'
+    networks:
+      - ai-va-network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:7002/mcp || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  flight-mcp:
+    build:
+      context: ../../mcp_servers/flight_mcp
+      dockerfile: Containerfile
+    container_name: flight-mcp-dev
+    restart: unless-stopped
+    environment:
+      - SERPAPI_API_KEY=${SERPAPI_API_KEY:-}
+      - HOST=0.0.0.0
+      - PORT=7003
+    ports:
+      - '7003:7003'
+    networks:
+      - ai-va-network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:7003/mcp || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   # MinIO service for attachments (optional - use profile 'attachments')
   minio:

--- a/deploy/local/compose.yaml
+++ b/deploy/local/compose.yaml
@@ -173,7 +173,7 @@ services:
     networks:
       - ai-va-network
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:7001/mcp || exit 1"]
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:7001/mcp')\" || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -194,7 +194,7 @@ services:
     networks:
       - ai-va-network
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:7002/mcp || exit 1"]
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:7002/mcp')\" || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -215,7 +215,7 @@ services:
     networks:
       - ai-va-network
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:7003/mcp || exit 1"]
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:7003/mcp')\" || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/deploy/local/compose.yaml
+++ b/deploy/local/compose.yaml
@@ -102,6 +102,10 @@ services:
       - LLAMASTACK_URL=${LLAMASTACK_URL:-http://llamastack:8321}
       - DISABLE_ATTACHMENTS=${DISABLE_ATTACHMENTS:-false}
       - ENABLE_COVERAGE=${ENABLE_COVERAGE:-false}
+      # LangGraph runner: use LlamaStack's OpenAI-compat endpoint
+      - LANGGRAPH_LLM_API_BASE=http://llamastack:8321/v1
+      - LANGGRAPH_LLM_API_KEY=no-key
+      - LANGGRAPH_DEFAULT_MODEL=${LANGGRAPH_DEFAULT_MODEL:-ollama/llama3.2:1b-instruct-fp16}
     ports:
       - '${BACKEND_PORT:-8000}:8000'
     volumes:

--- a/deploy/local/compose.yaml
+++ b/deploy/local/compose.yaml
@@ -69,6 +69,9 @@ services:
     platform: linux/amd64
     restart: unless-stopped
     user: "0:0"
+    env_file:
+      - path: ../../.env
+        required: false
     environment:
       - RUN_CONFIG_PATH=/app-config/config.yaml
     ports:

--- a/deploy/local/llamastack-run.yaml
+++ b/deploy/local/llamastack-run.yaml
@@ -33,6 +33,10 @@ providers:
   tool_runtime:
   - provider_id: model-context-protocol
     provider_type: remote::model-context-protocol
+  - provider_id: tavily-search
+    provider_type: remote::tavily-search
+    config:
+      api_key: ${env.TAVILY_API_KEY:}
 storage:
   backends:
     kv_default:
@@ -64,7 +68,9 @@ registered_resources:
   datasets: []
   scoring_fns: []
   benchmarks: []
-  tool_groups: []
+  tool_groups:
+  - toolgroup_id: "builtin::websearch"
+    provider_id: tavily-search
 server:
   port: 8321
 telemetry:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,8 @@
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "rehype-raw": "^7.0.0",
-        "rehype-sanitize": "^6.0.0"
+        "rehype-sanitize": "^6.0.0",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,8 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "rehype-raw": "^7.0.0",
-    "rehype-sanitize": "^6.0.0"
+    "rehype-sanitize": "^6.0.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",

--- a/frontend/src/components/ExpandableContent.tsx
+++ b/frontend/src/components/ExpandableContent.tsx
@@ -189,6 +189,12 @@ interface GraphNodeOutputSectionProps {
   outputText: string;
 }
 
+const statusIcon = (s: GraphNodeStatus) => {
+  if (s === 'completed') return <span style={{ color: 'var(--pf-v6-global--success-color--100, #3e8635)', marginRight: 6, fontSize: '0.9em' }}>✓</span>;
+  if (s === 'running') return <Spinner size="sm" style={{ marginRight: 6 }} aria-label="running" />;
+  return <span style={{ color: '#d2d2d2', marginRight: 6, fontSize: '0.9em' }}>○</span>;
+};
+
 export const GraphNodeOutputSection: React.FC<GraphNodeOutputSectionProps> = ({
   nodeId,
   label,
@@ -197,13 +203,19 @@ export const GraphNodeOutputSection: React.FC<GraphNodeOutputSectionProps> = ({
 }) => {
   const [isExpanded, setIsExpanded] = useState(status === 'running');
 
-  const statusEmoji = status === 'completed' ? '✅' : status === 'running' ? '⏳' : '⬜';
   const preview =
     outputText.length > 120 ? outputText.slice(0, 120).trimEnd() + '...' : outputText;
 
+  const toggle = (
+    <span style={{ display: 'inline-flex', alignItems: 'center' }}>
+      {statusIcon(status)}
+      {label}
+    </span>
+  );
+
   return (
     <ExpandableSection
-      toggleText={`${statusEmoji} ${label}`}
+      toggleContent={toggle}
       isExpanded={isExpanded}
       onToggle={(_event, expanded) => setIsExpanded(expanded)}
       isIndented

--- a/frontend/src/components/ExpandableContent.tsx
+++ b/frontend/src/components/ExpandableContent.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { ExpandableSection, ProgressStep, ProgressStepper, Spinner } from '@patternfly/react-core';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { GraphNodeStatus } from '@/types/chat';
 
 interface ReasoningSectionProps {
@@ -117,8 +118,8 @@ interface TextContentProps {
 export const TextContent: React.FC<TextContentProps> = ({ text, isMarkdown = false }) => {
   if (isMarkdown) {
     return (
-      <div className="markdown-content">
-        <ReactMarkdown>{text}</ReactMarkdown>
+      <div className="pf-v6-c-content">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
       </div>
     );
   }
@@ -228,8 +229,13 @@ export const GraphNodeOutputSection: React.FC<GraphNodeOutputSectionProps> = ({
         }}
       >
         {outputText ? (
-          <div className="markdown-content">
-            <ReactMarkdown>{isExpanded ? outputText : preview}</ReactMarkdown>
+          <div
+            className="pf-v6-c-content"
+            style={{ overflowX: 'auto', fontSize: '0.875rem' }}
+          >
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              {isExpanded ? outputText : preview}
+            </ReactMarkdown>
           </div>
         ) : (
           <div style={{ color: '#6a6e73', fontStyle: 'italic' }}>

--- a/frontend/src/components/ExpandableContent.tsx
+++ b/frontend/src/components/ExpandableContent.tsx
@@ -191,21 +191,31 @@ interface GraphNodeOutputSectionProps {
 }
 
 const statusIcon = (s: GraphNodeStatus) => {
-  if (s === 'completed') return <span style={{ color: 'var(--pf-v6-global--success-color--100, #3e8635)', marginRight: 6, fontSize: '0.9em' }}>✓</span>;
+  if (s === 'completed')
+    return (
+      <span
+        style={{
+          color: 'var(--pf-v6-global--success-color--100, #3e8635)',
+          marginRight: 6,
+          fontSize: '0.9em',
+        }}
+      >
+        ✓
+      </span>
+    );
   if (s === 'running') return <Spinner size="sm" style={{ marginRight: 6 }} aria-label="running" />;
   return <span style={{ color: '#d2d2d2', marginRight: 6, fontSize: '0.9em' }}>○</span>;
 };
 
 export const GraphNodeOutputSection: React.FC<GraphNodeOutputSectionProps> = ({
-  nodeId,
+  nodeId: _nodeId,
   label,
   status,
   outputText,
 }) => {
   const [isExpanded, setIsExpanded] = useState(status === 'running');
 
-  const preview =
-    outputText.length > 120 ? outputText.slice(0, 120).trimEnd() + '...' : outputText;
+  const preview = outputText.length > 120 ? outputText.slice(0, 120).trimEnd() + '...' : outputText;
 
   const toggle = (
     <span style={{ display: 'inline-flex', alignItems: 'center' }}>
@@ -229,10 +239,7 @@ export const GraphNodeOutputSection: React.FC<GraphNodeOutputSectionProps> = ({
         }}
       >
         {outputText ? (
-          <div
-            className="pf-v6-c-content"
-            style={{ overflowX: 'auto', fontSize: '0.875rem' }}
-          >
+          <div className="pf-v6-c-content" style={{ overflowX: 'auto', fontSize: '0.875rem' }}>
             <ReactMarkdown remarkPlugins={[remarkGfm]}>
               {isExpanded ? outputText : preview}
             </ReactMarkdown>

--- a/frontend/src/components/agent-card.tsx
+++ b/frontend/src/components/agent-card.tsx
@@ -168,6 +168,13 @@ export function AgentCard({ agent, isAssigned }: AgentCardProps) {
                   {agent.model_name}
                 </Title>
               </FlexItem>
+              {agent.runner_type && agent.runner_type !== 'llamastack' && (
+                <FlexItem>
+                  <Label color="blue" isCompact>
+                    {agent.runner_type}
+                  </Label>
+                </FlexItem>
+              )}
             </Flex>
           </CardTitle>
         </CardHeader>

--- a/frontend/src/components/chat.tsx
+++ b/frontend/src/components/chat.tsx
@@ -49,7 +49,12 @@ import userAvatar from '../assets/img/user-avatar.svg';
 import { ATTACHMENTS_API_ENDPOINT } from '@/config/api';
 import { SimpleContentItem } from '@/types/chat';
 import { getTemplateDetails } from '@/services/agent-templates';
-import { ReasoningSection, ToolCallSection } from './ExpandableContent';
+import {
+  ReasoningSection,
+  ToolCallSection,
+  GraphProgressTracker,
+  GraphNodeOutputSection,
+} from './ExpandableContent';
 
 const footnoteProps = {
   label: 'ChatBot uses AI. Check for mistakes.',
@@ -145,10 +150,56 @@ export function Chat({ preSelectedAgentId }: ChatProps = {}) {
     const textParts: string[] = [];
     const expandableComponents: React.ReactNode[] = [];
 
+    // Collect graph node items to detect graph agent responses
+    const graphNodes = content.filter(
+      (item): item is import('@/types/chat').GraphNodeContentItem => item.type === 'graph_node'
+    );
+    const graphNodeIds = new Set(graphNodes.map((n) => n.node_id));
+
+    // Build a map of node_id -> accumulated output text for graph responses
+    const nodeOutputMap = new Map<string, string>();
+    if (graphNodes.length > 0) {
+      content.forEach((item) => {
+        if (item.type === 'output_text' && item.id && graphNodeIds.has(item.id)) {
+          const existing = nodeOutputMap.get(item.id) || '';
+          nodeOutputMap.set(item.id, existing + item.text);
+        }
+      });
+    }
+
+    // If graph nodes are present, render progress tracker + per-node output sections
+    if (graphNodes.length > 0) {
+      expandableComponents.push(
+        <GraphProgressTracker
+          key="graph-progress"
+          nodes={graphNodes.map((n) => ({
+            node_id: n.node_id,
+            label: n.label,
+            status: n.status,
+          }))}
+        />
+      );
+
+      graphNodes.forEach((node) => {
+        const outputText = nodeOutputMap.get(node.node_id) || '';
+        expandableComponents.push(
+          <GraphNodeOutputSection
+            key={`graph-node-${node.node_id}`}
+            nodeId={node.node_id}
+            label={node.label}
+            status={node.status}
+            outputText={outputText}
+          />
+        );
+      });
+    }
+
     content.forEach((item, index) => {
       if (item.type === 'input_text') {
         textParts.push(item.text);
       } else if (item.type === 'output_text') {
+        // Skip output_text items that belong to graph nodes (rendered in sections above)
+        if (item.id && graphNodeIds.has(item.id)) return;
         textParts.push(item.text);
       } else if (item.type === 'input_image') {
         const imageUrl = item.image_url.startsWith('/')
@@ -176,6 +227,7 @@ export function Chat({ preSelectedAgentId }: ChatProps = {}) {
           />
         );
       }
+      // graph_node items are handled above
     });
 
     return {

--- a/frontend/src/components/chat.tsx
+++ b/frontend/src/components/chat.tsx
@@ -52,7 +52,6 @@ import { getTemplateDetails } from '@/services/agent-templates';
 import {
   ReasoningSection,
   ToolCallSection,
-  GraphProgressTracker,
   GraphNodeOutputSection,
 } from './ExpandableContent';
 
@@ -167,19 +166,7 @@ export function Chat({ preSelectedAgentId }: ChatProps = {}) {
       });
     }
 
-    // If graph nodes are present, render progress tracker + per-node output sections
     if (graphNodes.length > 0) {
-      expandableComponents.push(
-        <GraphProgressTracker
-          key="graph-progress"
-          nodes={graphNodes.map((n) => ({
-            node_id: n.node_id,
-            label: n.label,
-            status: n.status,
-          }))}
-        />
-      );
-
       graphNodes.forEach((node) => {
         const outputText = nodeOutputMap.get(node.node_id) || '';
         expandableComponents.push(

--- a/frontend/src/components/chat.tsx
+++ b/frontend/src/components/chat.tsx
@@ -49,11 +49,7 @@ import userAvatar from '../assets/img/user-avatar.svg';
 import { ATTACHMENTS_API_ENDPOINT } from '@/config/api';
 import { SimpleContentItem } from '@/types/chat';
 import { getTemplateDetails } from '@/services/agent-templates';
-import {
-  ReasoningSection,
-  ToolCallSection,
-  GraphNodeOutputSection,
-} from './ExpandableContent';
+import { ReasoningSection, ToolCallSection, GraphNodeOutputSection } from './ExpandableContent';
 
 const footnoteProps = {
   label: 'ChatBot uses AI. Check for mistakes.',

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -2,7 +2,14 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { CHAT_API_ENDPOINT } from '../config/api';
 import { fetchChatSession, createChatSession } from '@/services/chat-sessions';
 import { ChatMessage, UseLlamaChatOptions, SimpleContentItem, StreamEvent } from '@/types/chat';
-import { handleReasoning, handleToolCall, handleResponse, handleError } from './useChat.helpers';
+import {
+  handleReasoning,
+  handleToolCall,
+  handleResponse,
+  handleError,
+  handleNodeStarted,
+  handleNodeCompleted,
+} from './useChat.helpers';
 
 // Re-export types for backward compatibility
 export type { ChatMessage, UseLlamaChatOptions } from '@/types/chat';
@@ -245,6 +252,10 @@ export function useChat(agentId: string, options?: UseLlamaChatOptions) {
                       return prev;
                     });
                   }
+                } else if (chunk.type === 'node_started') {
+                  scheduleUpdate((prev) => handleNodeStarted(prev, chunk));
+                } else if (chunk.type === 'node_completed') {
+                  scheduleUpdate((prev) => handleNodeCompleted(prev, chunk));
                 } else if (chunk.type === 'error') {
                   console.error('Stream error:', chunk.message);
                   setIsLoading(false);

--- a/frontend/src/routes/_protected/_admin/config/agents.tsx
+++ b/frontend/src/routes/_protected/_admin/config/agents.tsx
@@ -127,6 +127,7 @@ function AgentTemplates() {
         template_model?: string;
         template_tool_ids?: string[];
         template_knowledge_base_ids?: string[];
+        runner_type?: string;
       }
     >
   >({});
@@ -305,6 +306,7 @@ function AgentTemplates() {
               template_model: templateModel,
               template_tool_ids: defaultToolIds,
               template_knowledge_base_ids: defaultKbIds,
+              runner_type: t.runner_type,
             };
           }
           return next;
@@ -711,7 +713,21 @@ function AgentTemplates() {
                       >
                         <Checkbox
                           id={`template-${pair.id}`}
-                          label={pair.name}
+                          label={
+                            <span>
+                              {pair.name}
+                              {templateOverrides[pair.id]?.runner_type &&
+                                templateOverrides[pair.id]?.runner_type !== 'llamastack' && (
+                                  <Label
+                                    color="blue"
+                                    isCompact
+                                    style={{ marginLeft: 8 }}
+                                  >
+                                    {templateOverrides[pair.id]?.runner_type}
+                                  </Label>
+                                )}
+                            </span>
+                          }
                           isChecked={selectedTemplateIds.includes(pair.id)}
                           onChange={(_event, checked: boolean) => {
                             setSelectedTemplateIds((prev: string[]) => {

--- a/frontend/src/routes/_protected/_admin/config/agents.tsx
+++ b/frontend/src/routes/_protected/_admin/config/agents.tsx
@@ -718,11 +718,7 @@ function AgentTemplates() {
                               {pair.name}
                               {templateOverrides[pair.id]?.runner_type &&
                                 templateOverrides[pair.id]?.runner_type !== 'llamastack' && (
-                                  <Label
-                                    color="blue"
-                                    isCompact
-                                    style={{ marginLeft: 8 }}
-                                  >
+                                  <Label color="blue" isCompact style={{ marginLeft: 8 }}>
                                     {templateOverrides[pair.id]?.runner_type}
                                   </Label>
                                 )}

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -19,6 +19,8 @@ export interface SamplingParameters {
   repetition_penalty?: number;
 }
 
+export type RunnerType = 'llamastack' | 'langgraph';
+
 export interface AgentBase {
   name: string;
   model_name: string;
@@ -26,6 +28,8 @@ export interface AgentBase {
   knowledge_base_ids: string[];
   input_shields: string[];
   output_shields: string[];
+  runner_type?: RunnerType;
+  graph_config?: Record<string, unknown> | null;
 }
 
 export interface Agent extends AgentBase, SamplingParameters {
@@ -64,6 +68,8 @@ export interface AgentTemplate {
     source_configuration: string[];
   };
   demo_questions?: string[];
+  runner_type?: RunnerType;
+  graph_config?: Record<string, unknown> | null;
 }
 
 export interface TemplateInitializationRequest {
@@ -75,6 +81,8 @@ export interface TemplateInitializationRequest {
   model_name?: string;
   tools?: { toolgroup_id: string }[];
   knowledge_base_ids?: string[];
+  runner_type?: RunnerType;
+  graph_config?: Record<string, unknown> | null;
 }
 
 export interface TemplateInitializationResponse {

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -59,12 +59,22 @@ export interface ImageContentItem {
   image_url: string;
 }
 
+export type GraphNodeStatus = 'pending' | 'running' | 'completed';
+
+export interface GraphNodeContentItem {
+  type: 'graph_node';
+  node_id: string;
+  label: string;
+  status: GraphNodeStatus;
+}
+
 export type SimpleContentItem =
   | TextContentItem
   | OutputTextContentItem
   | ReasoningContentItem
   | ToolCallContentItem
-  | ImageContentItem;
+  | ImageContentItem
+  | GraphNodeContentItem;
 
 export interface UseLlamaChatOptions {
   onError?: (error: Error) => void;
@@ -128,4 +138,20 @@ export interface ErrorEvent extends BaseStreamEvent {
   message: string;
 }
 
-export type StreamEvent = ReasoningEvent | ToolCallEvent | ResponseEvent | ErrorEvent;
+export interface NodeStartedEvent extends BaseStreamEvent {
+  type: 'node_started';
+  node: string;
+}
+
+export interface NodeCompletedEvent extends BaseStreamEvent {
+  type: 'node_completed';
+  node: string;
+}
+
+export type StreamEvent =
+  | ReasoningEvent
+  | ToolCallEvent
+  | ResponseEvent
+  | ErrorEvent
+  | NodeStartedEvent
+  | NodeCompletedEvent;

--- a/mcp_servers/flight_mcp/Containerfile
+++ b/mcp_servers/flight_mcp/Containerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY server.py .
+
+ENV PYTHONUNBUFFERED=1
+
+CMD ["python", "server.py"]

--- a/mcp_servers/flight_mcp/requirements.txt
+++ b/mcp_servers/flight_mcp/requirements.txt
@@ -1,0 +1,2 @@
+mcp>=1.26.0
+requests

--- a/mcp_servers/flight_mcp/server.py
+++ b/mcp_servers/flight_mcp/server.py
@@ -1,0 +1,258 @@
+import json
+import logging
+import os
+import re
+from typing import Any, Dict, Iterable
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("flight_mcp")
+
+mcp = FastMCP(
+    "flight_mcp",
+    host=os.getenv("HOST", "0.0.0.0"),
+    port=int(os.getenv("PORT", "8000")),
+)
+
+
+def _extract_iata(value: str) -> str:
+    match = re.search(r"\b([A-Z]{3})\b", value.upper())
+    return match.group(1) if match else ""
+
+
+def _coerce_list(value: str) -> list[str]:
+    raw = value.strip()
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, list):
+            return [str(item).strip() for item in parsed if str(item).strip()]
+    except json.JSONDecodeError:
+        pass
+    json_match = re.search(r"\[[\s\S]*?\]", raw)
+    if json_match:
+        try:
+            parsed = json.loads(json_match.group(0))
+            if isinstance(parsed, list):
+                return [str(item).strip() for item in parsed if str(item).strip()]
+        except json.JSONDecodeError:
+            pass
+    if "\n" in raw:
+        lines = [line.strip("- ").strip() for line in raw.splitlines() if line.strip()]
+        cleaned = [line for line in lines if "http" not in line.lower()]
+        cleaned = [
+            line
+            for line in cleaned
+            if "json array" not in line.lower()
+            and "here is" not in line.lower()
+            and not line.startswith("```")
+        ]
+        return cleaned if cleaned else lines
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _extract_city_candidates(items: list[str]) -> list[str]:
+    candidates: list[str] = []
+    for item in items:
+        if not item:
+            continue
+        if "," in item:
+            parts = [part.strip() for part in item.split(",") if part.strip()]
+            if parts:
+                candidates.append(parts[-1])
+            continue
+        candidates.append(item)
+    return candidates
+
+
+def _extract_first_location(value: str) -> str:
+    raw = value.strip()
+    if not raw:
+        return ""
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, list) and parsed:
+            return str(parsed[0])
+    except json.JSONDecodeError:
+        pass
+    if "\n" in raw:
+        lines = [line.strip("- ").strip() for line in raw.splitlines() if line.strip()]
+        cleaned = [line for line in lines if "http" not in line.lower()]
+        return cleaned[0] if cleaned else lines[0]
+    return raw
+
+
+def _find_iata_in_candidates(candidates: Iterable[dict]) -> str:
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+        for key in ("iata_code", "iata", "code"):
+            code = item.get(key)
+            if isinstance(code, str) and _extract_iata(code):
+                return _extract_iata(code)
+        for val in item.values():
+            if isinstance(val, str):
+                code = _extract_iata(val)
+                if code:
+                    return code
+    return ""
+
+
+def _resolve_airport_code(value: str, api_key: str) -> str:
+    value = _extract_first_location(value)
+    code = _extract_iata(value)
+    if code:
+        return code
+
+    for query in (value, f"{value} airport", f"{value} international airport"):
+        try:
+            response = requests.get(
+                "https://serpapi.com/locations.json",
+                params={"q": query, "api_key": api_key},
+                timeout=20,
+            )
+            response.raise_for_status()
+            data = response.json()
+        except Exception as exc:
+            logger.warning("IATA lookup failed for %s: %s", query, exc)
+            continue
+
+        if isinstance(data, list):
+            code = _find_iata_in_candidates(data)
+            if code:
+                return code
+        elif isinstance(data, dict):
+            for key in ("locations", "suggested_locations", "airports"):
+                if isinstance(data.get(key), list):
+                    code = _find_iata_in_candidates(data.get(key))
+                    if code:
+                        return code
+    return ""
+
+
+@mcp.tool()
+def iata_lookup(location: str) -> str:
+    """Resolve a city/region into a 3-letter IATA airport code."""
+    api_key = os.getenv("SERPAPI_API_KEY")
+    if not api_key:
+        return "SERPAPI_API_KEY is not set. Provide it to enable flight research."
+    if not location:
+        return "Location is required to resolve IATA code."
+
+    code = _resolve_airport_code(location, api_key)
+    if not code:
+        return "Unable to resolve IATA code for location."
+    return code
+
+
+@mcp.tool()
+def google_flights_search(
+    origin: str,
+    destination: str,
+    depart_date: str,
+    return_date: str,
+    passengers: int = 1,
+    cabin: str = "economy",
+) -> str:
+    """Find round-trip flight options using SerpApi Google Flights."""
+    logger.info("google_flights_search origin=%s destination=%s", origin, destination)
+    api_key = os.getenv("SERPAPI_API_KEY")
+    if not api_key:
+        return "SERPAPI_API_KEY is not set. Provide it to enable flight research."
+    if not origin or not destination:
+        return "Origin and destination are required to search flights."
+    if not return_date:
+        return "return_date is required for round-trip searches. Provide YYYY-MM-DD."
+
+    origin_code = _resolve_airport_code(origin, api_key)
+    if not origin_code:
+        return (
+            "Unable to resolve origin airport code. Provide a 3-letter IATA code "
+            "(e.g., RDU, SFO)."
+        )
+
+    cabin_map = {
+        "economy": 1,
+        "premium_economy": 2,
+        "business": 3,
+        "first": 4,
+    }
+    travel_class = cabin_map.get(cabin.lower(), 1)
+
+    destinations = _coerce_list(destination) or [destination]
+    city_candidates = _extract_city_candidates(destinations)
+    if city_candidates:
+        destinations = city_candidates
+    selected = []
+    if destinations:
+        selected.append(destinations[0])
+    if len(destinations) > 1:
+        selected.append(destinations[-1])
+    max_destinations = 2
+    results = []
+
+    for dest in selected[:max_destinations]:
+        destination_code = _resolve_airport_code(dest, api_key)
+        if not destination_code:
+            continue
+
+        params: Dict[str, Any] = {
+            "engine": "google_flights",
+            "departure_id": origin_code,
+            "arrival_id": destination_code,
+            "outbound_date": depart_date,
+            "return_date": return_date,
+            "type": 1,
+            "adults": passengers,
+            "travel_class": travel_class,
+            "hl": "en",
+            "gl": "us",
+            "api_key": api_key,
+        }
+        response = requests.get(
+            "https://serpapi.com/search.json",
+            params=params,
+            timeout=30,
+        )
+        if response.status_code >= 400:
+            results.append(
+                f"- SerpApi error {response.status_code} for "
+                f"{destination_code}: {response.text}"
+            )
+            continue
+        response.raise_for_status()
+        data = response.json()
+        flights = data.get("best_flights") or data.get("other_flights") or []
+        if not flights:
+            results.append(f"- No flights returned for {destination_code}.")
+            continue
+
+        results.append(f"Destination {destination_code}:")
+        for option in flights[:5]:
+            price = option.get("price")
+            duration = option.get("total_duration")
+            segments = option.get("flights", [])
+            if segments:
+                first = segments[0]
+                airline = first.get("airline", "Unknown airline")
+                flight_num = first.get("flight_number", "")
+                dep = first.get("departure_airport", {}).get("id", origin_code)
+                arr = first.get("arrival_airport", {}).get("id", destination_code)
+            else:
+                airline = "Unknown airline"
+                flight_num = ""
+                dep = origin_code
+                arr = destination_code
+            results.append(
+                f"- {airline} {flight_num} {dep}->{arr} "
+                f"| {duration} mins | ${price}"
+            )
+
+    return "\n".join(results)
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http")

--- a/mcp_servers/flight_mcp/server.py
+++ b/mcp_servers/flight_mcp/server.py
@@ -85,6 +85,40 @@ def _extract_first_location(value: str) -> str:
     return raw
 
 
+_CITY_AIRPORT_MAP: Dict[str, str] = {
+    "paris": "CDG",
+    "london": "LHR",
+    "new york": "JFK",
+    "los angeles": "LAX",
+    "chicago": "ORD",
+    "san francisco": "SFO",
+    "tokyo": "NRT",
+    "rome": "FCO",
+    "berlin": "BER",
+    "madrid": "MAD",
+    "amsterdam": "AMS",
+    "dubai": "DXB",
+    "singapore": "SIN",
+    "hong kong": "HKG",
+    "sydney": "SYD",
+    "toronto": "YYZ",
+    "mumbai": "BOM",
+    "bangkok": "BKK",
+    "istanbul": "IST",
+    "seoul": "ICN",
+    "miami": "MIA",
+    "washington": "IAD",
+    "boston": "BOS",
+    "atlanta": "ATL",
+    "dallas": "DFW",
+    "denver": "DEN",
+    "seattle": "SEA",
+    "lisbon": "LIS",
+    "barcelona": "BCN",
+    "mexico city": "MEX",
+}
+
+
 def _find_iata_in_candidates(candidates: Iterable[dict]) -> str:
     for item in candidates:
         if not isinstance(item, dict):
@@ -93,16 +127,16 @@ def _find_iata_in_candidates(candidates: Iterable[dict]) -> str:
             code = item.get(key)
             if isinstance(code, str) and _extract_iata(code):
                 return _extract_iata(code)
-        for val in item.values():
-            if isinstance(val, str):
-                code = _extract_iata(val)
-                if code:
-                    return code
     return ""
 
 
 def _resolve_airport_code(value: str, api_key: str) -> str:
     value = _extract_first_location(value)
+
+    known = _CITY_AIRPORT_MAP.get(value.lower().strip())
+    if known:
+        return known
+
     code = _extract_iata(value)
     if code:
         return code

--- a/mcp_servers/hotel_mcp/Containerfile
+++ b/mcp_servers/hotel_mcp/Containerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY server.py .
+
+ENV PYTHONUNBUFFERED=1
+
+CMD ["python", "server.py"]

--- a/mcp_servers/hotel_mcp/requirements.txt
+++ b/mcp_servers/hotel_mcp/requirements.txt
@@ -1,0 +1,2 @@
+mcp>=1.26.0
+requests

--- a/mcp_servers/hotel_mcp/server.py
+++ b/mcp_servers/hotel_mcp/server.py
@@ -1,0 +1,94 @@
+import logging
+import os
+from typing import Any, Dict
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("hotel_mcp")
+
+mcp = FastMCP(
+    "hotel_mcp",
+    host=os.getenv("HOST", "0.0.0.0"),
+    port=int(os.getenv("PORT", "8000")),
+)
+
+
+@mcp.tool()
+def google_hotels_search(
+    destination: str,
+    start_date: str,
+    end_date: str,
+    adults: int = 2,
+    preferences: str = "",
+) -> str:
+    """Find hotel options for a destination and date range using SerpApi Google Hotels."""
+    logger.info("google_hotels_search destination=%s", destination)
+    api_key = os.getenv("SERPAPI_API_KEY")
+    if not api_key:
+        return "SERPAPI_API_KEY is not set. Provide it to enable hotel research."
+    if not destination:
+        return "Destination is required to search hotels."
+
+    query = destination
+    if preferences:
+        query = f"{destination} {preferences}"
+
+    params: Dict[str, Any] = {
+        "engine": "google_hotels",
+        "q": query,
+        "hl": "en",
+        "gl": "us",
+        "check_in_date": start_date,
+        "check_out_date": end_date,
+        "currency": "USD",
+        "api_key": api_key,
+    }
+    if adults:
+        params["adults"] = adults
+
+    def _fetch(search_params: Dict[str, Any]) -> Dict[str, Any]:
+        response = requests.get(
+            "https://serpapi.com/search.json",
+            params=search_params,
+            timeout=30,
+        )
+        if response.status_code >= 400:
+            raise RuntimeError(f"SerpApi error {response.status_code}: {response.text}")
+        response.raise_for_status()
+        return response.json()
+
+    try:
+        data = _fetch(params)
+    except RuntimeError as exc:
+        return str(exc)
+
+    properties = data.get("properties") or data.get("hotels") or []
+    if not properties:
+        retry_params = dict(params)
+        retry_params["q"] = f"{query} hotels"
+        try:
+            data = _fetch(retry_params)
+        except RuntimeError as exc:
+            return str(exc)
+        properties = data.get("properties") or data.get("hotels") or []
+        if not properties:
+            return (
+                "No hotels returned from SerpApi. "
+                f"Tried query='{params['q']}' and '{retry_params['q']}'."
+            )
+
+    formatted = []
+    for prop in properties[:6]:
+        name = prop.get("name", "Unknown hotel")
+        rate = prop.get("rate_per_night", {}).get("lowest", "")
+        rating = prop.get("rating", "")
+        location = prop.get("location", "")
+        formatted.append(f"- {name} | {location} | rating: {rating} | rate: {rate}")
+
+    return "\n".join(formatted)
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http")

--- a/mcp_servers/travel_research_mcp/Containerfile
+++ b/mcp_servers/travel_research_mcp/Containerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY server.py .
+
+ENV PYTHONUNBUFFERED=1
+
+CMD ["python", "server.py"]

--- a/mcp_servers/travel_research_mcp/requirements.txt
+++ b/mcp_servers/travel_research_mcp/requirements.txt
@@ -1,0 +1,2 @@
+mcp>=1.26.0
+requests

--- a/mcp_servers/travel_research_mcp/server.py
+++ b/mcp_servers/travel_research_mcp/server.py
@@ -1,0 +1,52 @@
+import logging
+import os
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("travel_research_mcp")
+
+mcp = FastMCP(
+    "travel_research_mcp",
+    host=os.getenv("HOST", "0.0.0.0"),
+    port=int(os.getenv("PORT", "8000")),
+)
+
+
+@mcp.tool()
+def tavily_travel_search(query: str, max_results: int = 5) -> str:
+    """Search the web for travel information about a destination or theme."""
+    logger.info("tavily_travel_search query=%s", query)
+    api_key = os.getenv("TAVILY_API_KEY")
+    if not api_key:
+        return "TAVILY_API_KEY is not set. Provide it to enable web research."
+
+    response = requests.post(
+        "https://api.tavily.com/search",
+        json={
+            "api_key": api_key,
+            "query": query,
+            "max_results": max_results,
+            "include_answer": True,
+            "include_raw_content": False,
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    data = response.json()
+    results = data.get("results", [])
+    if not results:
+        return "No results returned from Tavily."
+
+    formatted = []
+    for item in results:
+        title = item.get("title", "Untitled")
+        url = item.get("url", "")
+        snippet = item.get("content", "")
+        formatted.append(f"- {title} ({url}): {snippet}")
+    return "\n".join(formatted)
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http")

--- a/tests/unit/test_graph_engine.py
+++ b/tests/unit/test_graph_engine.py
@@ -1,0 +1,480 @@
+"""
+Unit tests for the declarative graph engine.
+
+Tests cover:
+- Environment variable expansion
+- Template rendering with _DotDict
+- Path resolution (_get_path)
+- List coercion (_coerce_list)
+- Argument normalisation and sanitisation
+- SSE event formatting
+- LLM node execution
+- MCP tool node execution (mocked)
+- MCP tool map node execution (mocked)
+- GraphEngine graph building and streaming
+- Runner dispatch (graph_config vs ReAct)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.services.runners.graph_engine import (
+    _coerce_list,
+    _DotDict,
+    _expand_env,
+    _get_path,
+    _normalize_arg,
+    _render_template,
+    _sanitize_args,
+    _sse,
+    _summarize_output,
+)
+
+# ---------------------------------------------------------------------------
+# Environment variable expansion
+# ---------------------------------------------------------------------------
+
+
+class TestExpandEnv:
+    """Test ${VAR:default} expansion."""
+
+    def test_simple_default(self):
+        result = _expand_env("${MISSING_VAR:http://localhost:8000}")
+        assert result == "http://localhost:8000"
+
+    def test_env_var_present(self):
+        with patch.dict(os.environ, {"TEST_URL": "http://custom:9000"}):
+            result = _expand_env("${TEST_URL:http://default}")
+            assert result == "http://custom:9000"
+
+    def test_nested_dict(self):
+        data = {"url": "${MISSING:http://fallback}", "port": 8080}
+        result = _expand_env(data)
+        assert result["url"] == "http://fallback"
+        assert result["port"] == 8080
+
+    def test_nested_list(self):
+        data = ["${MISSING:val1}", "literal"]
+        result = _expand_env(data)
+        assert result == ["val1", "literal"]
+
+    def test_no_pattern(self):
+        assert _expand_env("no pattern here") == "no pattern here"
+        assert _expand_env(42) == 42
+
+
+# ---------------------------------------------------------------------------
+# Template rendering
+# ---------------------------------------------------------------------------
+
+
+class TestRenderTemplate:
+    """Test {inputs.x} / {outputs.y} rendering."""
+
+    def test_basic_render(self):
+        ctx = {"inputs": _DotDict({"city": "Tokyo"})}
+        assert _render_template("{inputs.city}", ctx) == "Tokyo"
+
+    def test_missing_key_returns_empty(self):
+        ctx = {"inputs": _DotDict({})}
+        result = _render_template("{inputs.missing}", ctx)
+        assert result == ""
+
+    def test_dict_render(self):
+        ctx = {"inputs": _DotDict({"dest": "Paris"})}
+        result = _render_template({"destination": "{inputs.dest}", "count": 5}, ctx)
+        assert result["destination"] == "Paris"
+        assert result["count"] == 5
+
+    def test_list_render(self):
+        ctx = {"inputs": _DotDict({"a": "X"})}
+        result = _render_template(["{inputs.a}", "literal"], ctx)
+        assert result == ["X", "literal"]
+
+    def test_keyerror_returns_original(self):
+        result = _render_template("{undefined_key}", {})
+        assert result == "{undefined_key}"
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+
+class TestGetPath:
+    """Test dot-path resolution."""
+
+    def test_simple_path(self):
+        data = {"outputs": {"task1": "result"}}
+        assert _get_path(data, "outputs.task1") == "result"
+
+    def test_nested_path(self):
+        data = {"a": {"b": {"c": "deep"}}}
+        assert _get_path(data, "a.b.c") == "deep"
+
+    def test_missing_path(self):
+        assert _get_path({"a": 1}, "b.c") == ""
+
+    def test_empty_path(self):
+        assert _get_path({"a": 1}, "") == ""
+
+
+# ---------------------------------------------------------------------------
+# List coercion
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceList:
+    """Test _coerce_list for various input formats."""
+
+    def test_list_passthrough(self):
+        assert _coerce_list(["a", "b"]) == ["a", "b"]
+
+    def test_json_string(self):
+        assert _coerce_list('["Tokyo", "Kyoto"]') == ["Tokyo", "Kyoto"]
+
+    def test_csv_string(self):
+        assert _coerce_list("a, b, c") == ["a", "b", "c"]
+
+    def test_newline_string(self):
+        assert _coerce_list("- item1\n- item2") == ["item1", "item2"]
+
+    def test_none(self):
+        assert _coerce_list(None) == []
+
+    def test_empty_string(self):
+        assert _coerce_list("") == []
+
+    def test_scalar(self):
+        assert _coerce_list(42) == ["42"]
+
+
+# ---------------------------------------------------------------------------
+# Argument normalisation
+# ---------------------------------------------------------------------------
+
+
+class TestArgNormalisation:
+    """Test _normalize_arg and _sanitize_args."""
+
+    def test_bool_string(self):
+        assert _normalize_arg("true") is True
+        assert _normalize_arg("false") is False
+
+    def test_int_string(self):
+        assert _normalize_arg("42") == 42
+
+    def test_float_string(self):
+        assert _normalize_arg("3.14") == 3.14
+
+    def test_regular_string(self):
+        assert _normalize_arg("hello") == "hello"
+
+    def test_sanitize_drops_empty(self):
+        result = _sanitize_args({"a": "val", "b": "", "c": None})
+        assert result == {"a": "val"}
+
+
+# ---------------------------------------------------------------------------
+# SSE helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSSEHelpers:
+    """Test SSE formatting and summarisation."""
+
+    def test_sse_format(self):
+        event = _sse("node_started", {"node": "task1"}, "sess-1")
+        assert event.startswith("data: ")
+        assert event.endswith("\n\n")
+        parsed = json.loads(event[len("data: ") : -2])
+        assert parsed["type"] == "node_started"
+        assert parsed["session_id"] == "sess-1"
+        assert parsed["node"] == "task1"
+
+    def test_summarize_output(self):
+        assert _summarize_output("First line\nSecond") == "First line"
+        assert _summarize_output("") == "No output"
+        assert _summarize_output("\n") == "Output generated"
+
+
+# ---------------------------------------------------------------------------
+# LLM node execution
+# ---------------------------------------------------------------------------
+
+
+class TestLLMNode:
+    """Test _run_llm_node with mocked LLM."""
+
+    @pytest.mark.asyncio
+    async def test_llm_node_success(self):
+        from backend.app.services.runners.graph_engine import _run_llm_node
+
+        mock_llm = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.content = "Five places in Tokyo"
+        mock_llm.ainvoke.return_value = mock_response
+
+        step = {"id": "test", "type": "llm", "prompt": "List places in {inputs.city}"}
+        result = await _run_llm_node(mock_llm, step, {"city": "Tokyo"}, {})
+        assert result == "Five places in Tokyo"
+        mock_llm.ainvoke.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_llm_node_error(self):
+        from backend.app.services.runners.graph_engine import _run_llm_node
+
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke.side_effect = Exception("LLM timeout")
+
+        step = {"id": "test", "type": "llm", "prompt": "Hello"}
+        result = await _run_llm_node(mock_llm, step, {}, {})
+        assert "LLM error" in result
+
+
+# ---------------------------------------------------------------------------
+# MCP tool node execution (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestMCPToolNode:
+    """Test _run_mcp_tool_node with mocked httpx."""
+
+    @pytest.mark.asyncio
+    async def test_mcp_tool_missing_tool_name(self):
+        from backend.app.services.runners.graph_engine import _run_mcp_tool_node
+
+        step = {
+            "id": "test",
+            "type": "mcp_tool",
+            "server": "my_server",
+            "tool": "",
+        }
+        servers = {"my_server": {"url": "http://localhost:7001/mcp"}}
+        result = await _run_mcp_tool_node(step, {}, {}, servers, "streamable-http")
+        assert "Missing tool name" in result
+
+    @pytest.mark.asyncio
+    async def test_mcp_tool_unsupported_transport(self):
+        from backend.app.services.runners.graph_engine import _run_mcp_tool_node
+
+        step = {
+            "id": "test",
+            "type": "mcp_tool",
+            "server": "s",
+            "tool": "my_tool",
+        }
+        servers = {"s": {"url": "http://x", "transport": "stdio"}}
+        result = await _run_mcp_tool_node(step, {}, {}, servers, "stdio")
+        assert "Unsupported" in result
+
+
+# ---------------------------------------------------------------------------
+# GraphEngine build and stream
+# ---------------------------------------------------------------------------
+
+
+class TestGraphEngine:
+    """Test GraphEngine building and streaming."""
+
+    @pytest.mark.asyncio
+    async def test_llm_only_graph(self):
+        """A graph with a single LLM node builds and streams correctly."""
+        from backend.app.services.runners.graph_engine import GraphEngine
+
+        config = {
+            "nodes": [
+                {
+                    "id": "greet",
+                    "type": "llm",
+                    "prompt": "Say hello to {inputs.name}",
+                }
+            ]
+        }
+
+        mock_llm = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.content = "Hello, Alice!"
+        mock_llm.ainvoke.return_value = mock_response
+
+        engine = GraphEngine(config=config, llm=mock_llm)
+        events = []
+        async for event in engine.run_streaming({"name": "Alice"}, "session-1"):
+            events.append(event)
+
+        parsed = [
+            json.loads(e[len("data: ") : -2]) for e in events if e.startswith("data: ")
+        ]
+
+        node_started = [p for p in parsed if p["type"] == "node_started"]
+        assert len(node_started) == 1
+        assert node_started[0]["node"] == "greet"
+
+        node_completed = [p for p in parsed if p["type"] == "node_completed"]
+        assert len(node_completed) == 1
+
+        responses = [p for p in parsed if p["type"] == "response"]
+        assert any("Hello, Alice!" in r.get("delta", "") for r in responses)
+
+    @pytest.mark.asyncio
+    async def test_multi_node_graph(self):
+        """A graph with two LLM nodes runs sequentially."""
+        from backend.app.services.runners.graph_engine import GraphEngine
+
+        config = {
+            "nodes": [
+                {"id": "step1", "type": "llm", "prompt": "Step 1"},
+                {"id": "step2", "type": "llm", "prompt": "Step 2"},
+            ]
+        }
+
+        mock_llm = AsyncMock()
+        call_count = 0
+
+        async def mock_ainvoke(messages):
+            nonlocal call_count
+            call_count += 1
+            resp = MagicMock()
+            resp.content = f"Result {call_count}"
+            return resp
+
+        mock_llm.ainvoke = mock_ainvoke
+
+        engine = GraphEngine(config=config, llm=mock_llm)
+        events = []
+        async for event in engine.run_streaming({}, "sess"):
+            events.append(event)
+
+        parsed = [
+            json.loads(e[len("data: ") : -2]) for e in events if e.startswith("data: ")
+        ]
+
+        nodes_started = [p["node"] for p in parsed if p["type"] == "node_started"]
+        assert nodes_started == ["step1", "step2"]
+
+    def test_empty_nodes_raises(self):
+        """GraphEngine raises on empty node list."""
+        from backend.app.services.runners.graph_engine import GraphEngine
+
+        with pytest.raises(ValueError, match="non-empty"):
+            GraphEngine(config={"nodes": []}, llm=MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# Runner dispatch (graph_config vs ReAct)
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerDispatch:
+    """Test that LangGraphRunner dispatches correctly based on graph_config."""
+
+    @pytest.fixture
+    def runner(self):
+        from backend.app.services.runners.langgraph_runner import (
+            LangGraphRunner,
+        )
+
+        return LangGraphRunner(
+            MagicMock(spec=Request),
+            AsyncMock(spec=AsyncSession),
+            uuid.uuid4(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_dispatches_to_graph_engine_when_config_present(self, runner):
+        """Agent with graph_config runs declarative graph, not ReAct."""
+        agent = MagicMock()
+        agent.id = uuid.uuid4()
+        agent.graph_config = {
+            "nodes": [
+                {"id": "greet", "type": "llm", "prompt": "Hello {inputs.message}"}
+            ]
+        }
+        agent.model_name = "test-model"
+        agent.temperature = None
+        agent.tools = []
+
+        mock_llm = MagicMock()
+
+        with patch(
+            "backend.app.services.runners.langgraph_runner._check_langgraph",
+            return_value=True,
+        ), patch.object(runner, "_create_llm", return_value=mock_llm), patch(
+            "backend.app.services.runners.graph_engine.GraphEngine"
+        ) as MockEngine, patch.object(
+            runner, "_update_session_title", new_callable=AsyncMock
+        ):
+            mock_engine_instance = MagicMock()
+
+            async def mock_stream(inputs, session_id):
+                yield 'data: {"type": "response", "session_id": "s1", "delta": "Hi"}\n\n'
+
+            mock_engine_instance.run_streaming = mock_stream
+            MockEngine.return_value = mock_engine_instance
+
+            events = []
+            async for event in runner.stream(agent, "s1", "Hello"):
+                events.append(event)
+
+            MockEngine.assert_called_once()
+            assert any("response" in e for e in events)
+            assert events[-1] == "data: [DONE]\n\n"
+
+    @pytest.mark.asyncio
+    async def test_dispatches_to_react_when_no_config(self, runner):
+        """Agent without graph_config uses ReAct (create_react_agent)."""
+        agent = MagicMock()
+        agent.id = uuid.uuid4()
+        agent.graph_config = None
+        agent.model_name = "test-model"
+        agent.prompt = "Be helpful."
+        agent.temperature = None
+        agent.tools = []
+        agent.max_infer_iters = 5
+
+        ai_chunk = MagicMock()
+        ai_chunk.content = "Hi!"
+        ai_chunk.__class__.__name__ = "AIMessageChunk"
+
+        ai_msg = MagicMock()
+        ai_msg.model_dump.return_value = {"type": "ai", "content": "Hi!"}
+
+        async def mock_astream(input_dict, config, stream_mode):
+            yield ("messages", (ai_chunk, {"langgraph_node": "agent"}))
+            yield ("updates", {"agent": {"messages": [ai_msg]}})
+            yield ("updates", {"__end__": None})
+
+        mock_graph = MagicMock()
+        mock_graph.astream = mock_astream
+
+        with patch(
+            "backend.app.services.runners.langgraph_runner._check_langgraph",
+            return_value=True,
+        ), patch(
+            "backend.app.services.runners.langgraph_runner.LangGraphRunner._create_llm"
+        ), patch(
+            "backend.app.services.runners.langgraph_runner._get_checkpointer"
+        ), patch(
+            "backend.app.services.runners.langgraph_runner.create_react_agent",
+            return_value=mock_graph,
+        ), patch(
+            "backend.app.services.runners.langgraph_runner.AIMessageChunk",
+            new=type(ai_chunk),
+        ), patch.object(
+            runner, "_update_session_title", new_callable=AsyncMock
+        ):
+            events = []
+            async for event in runner.stream(agent, "s1", "Hello"):
+                events.append(event)
+
+            response_events = [e for e in events if '"type": "response"' in e]
+            assert len(response_events) >= 1
+            assert events[-1] == "data: [DONE]\n\n"

--- a/tests/unit/test_langgraph_runner.py
+++ b/tests/unit/test_langgraph_runner.py
@@ -1,0 +1,569 @@
+"""
+Unit tests for the LangGraph runner.
+
+Tests cover:
+- ChatService routing to LangGraphRunner
+- LangGraphRunner instantiation and BaseRunner compliance
+- Input message building from various prompt formats
+- SSE event formatting
+- Message-to-dict normalisation
+- Streaming with mocked LangGraph agent (messages + updates modes)
+- MCP tool resolution (success and failure paths)
+- Graceful handling when langgraph is not installed
+- Session title update
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.models.agent import VirtualAgent
+from backend.app.services.chat import ChatService
+from backend.app.services.runners.base import BaseRunner
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_request():
+    return MagicMock(spec=Request)
+
+
+@pytest.fixture
+def mock_db_session():
+    session = AsyncMock(spec=AsyncSession)
+    session.execute = AsyncMock()
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def user_id():
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def chat_service(mock_request, mock_db_session, user_id):
+    return ChatService(mock_request, mock_db_session, user_id)
+
+
+@pytest.fixture
+def mock_agent():
+    """Create a mock VirtualAgent configured for LangGraph."""
+    agent = MagicMock(spec=VirtualAgent)
+    agent.id = uuid.uuid4()
+    agent.name = "test-langgraph-agent"
+    agent.runner_type = "langgraph"
+    agent.model_name = "test-model"
+    agent.prompt = "You are a helpful test assistant."
+    agent.tools = []
+    agent.vector_store_ids = []
+    agent.knowledge_base_ids = []
+    agent.input_shields = []
+    agent.output_shields = []
+    agent.temperature = None
+    agent.max_infer_iters = 10
+    return agent
+
+
+@pytest.fixture
+def langgraph_runner(mock_request, mock_db_session, user_id):
+    """Create a LangGraphRunner with mock dependencies."""
+    from backend.app.services.runners.langgraph_runner import LangGraphRunner
+
+    return LangGraphRunner(mock_request, mock_db_session, user_id)
+
+
+# ---------------------------------------------------------------------------
+# ChatService routing
+# ---------------------------------------------------------------------------
+
+
+class TestChatServiceLangGraphRouting:
+    """Test that ChatService routes to LangGraphRunner."""
+
+    def test_get_runner_langgraph(self, chat_service):
+        """runner_type 'langgraph' returns a LangGraphRunner."""
+        from backend.app.services.runners.langgraph_runner import (
+            LangGraphRunner,
+        )
+
+        runner = chat_service._get_runner("langgraph")
+        assert isinstance(runner, LangGraphRunner)
+
+    def test_langgraph_runner_is_base_runner(self, chat_service):
+        """LangGraphRunner is a BaseRunner subclass."""
+        runner = chat_service._get_runner("langgraph")
+        assert isinstance(runner, BaseRunner)
+
+    def test_runner_preserves_dependencies(
+        self, chat_service, mock_request, mock_db_session, user_id
+    ):
+        """LangGraphRunner receives the same deps as ChatService."""
+        runner = chat_service._get_runner("langgraph")
+        assert runner.request is mock_request
+        assert runner.db is mock_db_session
+        assert runner.user_id == user_id
+
+
+# ---------------------------------------------------------------------------
+# Input message building
+# ---------------------------------------------------------------------------
+
+
+class TestBuildInputMessages:
+    """Test _build_input_messages for various prompt types."""
+
+    def test_string_prompt(self, langgraph_runner):
+        msgs = langgraph_runner._build_input_messages("Hello world")
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "user"
+        assert msgs[0]["content"] == "Hello world"
+
+    def test_list_of_content_items(self, langgraph_runner):
+        items = [
+            SimpleNamespace(text="Hello", type="input_text"),
+            SimpleNamespace(text=" world", type="input_text"),
+        ]
+        msgs = langgraph_runner._build_input_messages(items)
+        assert msgs[0]["content"] == "Hello\n world"
+
+    def test_single_content_item(self, langgraph_runner):
+        item = SimpleNamespace(text="Hi there")
+        msgs = langgraph_runner._build_input_messages(item)
+        assert msgs[0]["content"] == "Hi there"
+
+    def test_empty_list(self, langgraph_runner):
+        msgs = langgraph_runner._build_input_messages([])
+        assert msgs[0]["role"] == "user"
+        assert msgs[0]["content"] == "[]"
+
+    def test_dict_items(self, langgraph_runner):
+        items = [{"text": "Hello from dict", "type": "input_text"}]
+        msgs = langgraph_runner._build_input_messages(items)
+        assert "Hello from dict" in msgs[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# SSE event formatting
+# ---------------------------------------------------------------------------
+
+
+class TestSSEFormatting:
+    """Test _sse helper produces valid SSE strings."""
+
+    def test_sse_format(self, langgraph_runner):
+        event = langgraph_runner._sse("response", {"delta": "hi"}, "sess-1")
+        assert event.startswith("data: ")
+        assert event.endswith("\n\n")
+        parsed = json.loads(event[len("data: ") : -2])
+        assert parsed["type"] == "response"
+        assert parsed["session_id"] == "sess-1"
+        assert parsed["delta"] == "hi"
+
+    def test_sse_error_event(self, langgraph_runner):
+        event = langgraph_runner._sse("error", {"message": "boom"}, "sess-2")
+        parsed = json.loads(event[len("data: ") : -2])
+        assert parsed["type"] == "error"
+        assert parsed["message"] == "boom"
+
+
+# ---------------------------------------------------------------------------
+# Message-to-dict normalisation
+# ---------------------------------------------------------------------------
+
+
+class TestMessageToDict:
+    """Test _message_to_dict for various LangChain message shapes."""
+
+    def test_with_model_dump(self, langgraph_runner):
+        msg = MagicMock()
+        msg.model_dump.return_value = {"type": "ai", "content": "hello"}
+        result = langgraph_runner._message_to_dict(msg)
+        assert result == {"type": "ai", "content": "hello"}
+
+    def test_with_tool_calls(self, langgraph_runner):
+        msg = MagicMock(spec=[])
+        msg.type = "ai"
+        msg.content = ""
+        msg.tool_calls = [{"id": "tc1", "name": "get_weather", "args": {"city": "SF"}}]
+        del msg.model_dump
+        del msg.dict
+        result = langgraph_runner._message_to_dict(msg)
+        assert result["tool_calls"][0]["name"] == "get_weather"
+
+    def test_tool_message(self, langgraph_runner):
+        msg = MagicMock()
+        msg.model_dump.return_value = {
+            "type": "tool",
+            "content": "sunny",
+            "tool_call_id": "tc1",
+            "name": "get_weather",
+        }
+        result = langgraph_runner._message_to_dict(msg)
+        assert result["type"] == "tool"
+        assert result["tool_call_id"] == "tc1"
+
+
+# ---------------------------------------------------------------------------
+# Streaming (mocked LangGraph agent)
+# ---------------------------------------------------------------------------
+
+
+class TestLangGraphStreaming:
+    """Test the stream method with a fully mocked LangGraph graph."""
+
+    @pytest.mark.asyncio
+    async def test_stream_simple_response(self, langgraph_runner, mock_agent):
+        """Agent generates a simple text response (no tools)."""
+
+        # Mock the AIMessageChunk for messages mode
+        ai_chunk_1 = MagicMock()
+        ai_chunk_1.content = "Hello"
+        ai_chunk_1.__class__.__name__ = "AIMessageChunk"
+
+        ai_chunk_2 = MagicMock()
+        ai_chunk_2.content = " there!"
+        ai_chunk_2.__class__.__name__ = "AIMessageChunk"
+
+        # Mock the complete AIMessage for updates mode
+        ai_message = MagicMock()
+        ai_message.model_dump.return_value = {
+            "type": "ai",
+            "content": "Hello there!",
+        }
+
+        # Simulate the interleaved stream
+        async def mock_astream(input_dict, config, stream_mode):
+            # Token 1
+            yield ("messages", (ai_chunk_1, {"langgraph_node": "agent"}))
+            # Token 2
+            yield ("messages", (ai_chunk_2, {"langgraph_node": "agent"}))
+            # Node complete
+            yield (
+                "updates",
+                {"agent": {"messages": [ai_message]}},
+            )
+            # Graph end
+            yield ("updates", {"__end__": None})
+
+        mock_graph = MagicMock()
+        mock_graph.astream = mock_astream
+
+        with patch(
+            "backend.app.services.runners.langgraph_runner._check_langgraph",
+            return_value=True,
+        ), patch(
+            "backend.app.services.runners.langgraph_runner.LangGraphRunner._create_llm"
+        ), patch(
+            "backend.app.services.runners.langgraph_runner._get_checkpointer"
+        ), patch(
+            "backend.app.services.runners.langgraph_runner.create_react_agent",
+            return_value=mock_graph,
+        ), patch(
+            "backend.app.services.runners.langgraph_runner.AIMessageChunk",
+            new=type(ai_chunk_1),
+        ), patch.object(
+            langgraph_runner,
+            "_update_session_title",
+            new_callable=AsyncMock,
+        ):
+            events = []
+            async for event in langgraph_runner.stream(mock_agent, "session-1", "Hi"):
+                events.append(event)
+
+            # Verify we got response deltas
+            response_events = [
+                e
+                for e in events
+                if e.startswith("data: ") and '"type": "response"' in e
+            ]
+            assert len(response_events) >= 2  # Two text deltas + completed
+
+            # Verify we got node events
+            node_events = [
+                e for e in events if "node_started" in e or "node_completed" in e
+            ]
+            assert len(node_events) >= 2  # started + completed for agent
+
+            # Verify stream ends with [DONE]
+            assert events[-1] == "data: [DONE]\n\n"
+
+    @pytest.mark.asyncio
+    async def test_stream_with_tool_call(self, langgraph_runner, mock_agent):
+        """Agent calls a tool and then responds."""
+
+        # Agent decides to call tool
+        ai_tool_msg = MagicMock()
+        ai_tool_msg.model_dump.return_value = {
+            "type": "ai",
+            "content": "",
+            "tool_calls": [
+                {"id": "tc-1", "name": "get_weather", "args": {"city": "SF"}}
+            ],
+        }
+
+        # Tool result
+        tool_result = MagicMock()
+        tool_result.model_dump.return_value = {
+            "type": "tool",
+            "content": "Sunny, 72F",
+            "tool_call_id": "tc-1",
+            "name": "get_weather",
+        }
+
+        # Final response
+        ai_chunk = MagicMock()
+        ai_chunk.content = "The weather in SF is sunny!"
+        ai_chunk.__class__.__name__ = "AIMessageChunk"
+
+        ai_final = MagicMock()
+        ai_final.model_dump.return_value = {
+            "type": "ai",
+            "content": "The weather in SF is sunny!",
+        }
+
+        async def mock_astream(input_dict, config, stream_mode):
+            # Agent calls tool
+            yield ("updates", {"agent": {"messages": [ai_tool_msg]}})
+            # Tool runs
+            yield ("updates", {"tools": {"messages": [tool_result]}})
+            # Final response (token stream)
+            yield ("messages", (ai_chunk, {"langgraph_node": "agent"}))
+            # Agent node done
+            yield ("updates", {"agent": {"messages": [ai_final]}})
+            yield ("updates", {"__end__": None})
+
+        mock_graph = MagicMock()
+        mock_graph.astream = mock_astream
+
+        with patch(
+            "backend.app.services.runners.langgraph_runner._check_langgraph",
+            return_value=True,
+        ), patch(
+            "backend.app.services.runners.langgraph_runner.LangGraphRunner._create_llm"
+        ), patch(
+            "backend.app.services.runners.langgraph_runner._get_checkpointer"
+        ), patch(
+            "backend.app.services.runners.langgraph_runner.create_react_agent",
+            return_value=mock_graph,
+        ), patch(
+            "backend.app.services.runners.langgraph_runner.AIMessageChunk",
+            new=type(ai_chunk),
+        ), patch.object(
+            langgraph_runner,
+            "_update_session_title",
+            new_callable=AsyncMock,
+        ):
+            events = []
+            async for event in langgraph_runner.stream(
+                mock_agent, "session-2", "Weather in SF?"
+            ):
+                events.append(event)
+
+            # Parse all events
+            parsed = []
+            for e in events:
+                if e.startswith("data: ") and e.strip() != "data: [DONE]":
+                    parsed.append(json.loads(e[len("data: ") :].strip()))
+
+            # Find tool_call events
+            tool_events = [p for p in parsed if p["type"] == "tool_call"]
+            assert len(tool_events) >= 2  # in_progress + completed
+
+            in_progress = [t for t in tool_events if t["status"] == "in_progress"]
+            completed = [t for t in tool_events if t["status"] == "completed"]
+            assert len(in_progress) >= 1
+            assert len(completed) >= 1
+            assert completed[0]["output"] == "Sunny, 72F"
+
+            assert events[-1] == "data: [DONE]\n\n"
+
+
+# ---------------------------------------------------------------------------
+# LangGraph not installed
+# ---------------------------------------------------------------------------
+
+
+class TestLangGraphNotInstalled:
+    """Test graceful handling when langgraph is not installed."""
+
+    @pytest.mark.asyncio
+    async def test_stream_without_langgraph(self, langgraph_runner, mock_agent):
+        """stream() emits an error and [DONE] if langgraph is missing."""
+        with patch(
+            "backend.app.services.runners.langgraph_runner._check_langgraph",
+            return_value=False,
+        ):
+            events = []
+            async for event in langgraph_runner.stream(mock_agent, "session-x", "Hi"):
+                events.append(event)
+
+            assert len(events) == 2
+            error_event = json.loads(events[0][len("data: ") :].strip())
+            assert error_event["type"] == "error"
+            assert "not installed" in error_event["message"]
+            assert events[-1] == "data: [DONE]\n\n"
+
+
+# ---------------------------------------------------------------------------
+# MCP resolution
+# ---------------------------------------------------------------------------
+
+
+class TestMCPResolution:
+    """Test _resolve_mcp_servers for various tool configurations."""
+
+    @pytest.mark.asyncio
+    async def test_no_tools(self, langgraph_runner):
+        result = await langgraph_runner._resolve_mcp_servers(None)
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_no_mcp_tools(self, langgraph_runner):
+        result = await langgraph_runner._resolve_mcp_servers(
+            [{"toolgroup_id": "builtin::rag"}]
+        )
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_mcp_resolution_failure_logged(self, langgraph_runner):
+        """MCP resolution failure is handled gracefully."""
+        with patch(
+            "backend.app.api.llamastack.get_client_from_request",
+            side_effect=Exception("No LlamaStack"),
+        ):
+            result = await langgraph_runner._resolve_mcp_servers(
+                [{"toolgroup_id": "mcp::test-server"}]
+            )
+            assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# LLM creation
+# ---------------------------------------------------------------------------
+
+
+class TestLLMCreation:
+    """Test _create_llm with various configurations."""
+
+    def test_create_llm_uses_agent_model(self, langgraph_runner, mock_agent):
+        """_create_llm uses the agent's model_name."""
+        with patch(
+            "backend.app.services.runners.langgraph_runner.settings"
+        ) as mock_settings:
+            mock_settings.LANGGRAPH_LLM_API_BASE = "http://localhost:8321/v1"
+            mock_settings.LANGGRAPH_LLM_API_KEY = "test-key"
+            mock_settings.LANGGRAPH_DEFAULT_MODEL = None
+            mock_settings.LLAMA_STACK_URL = None
+
+            with patch(
+                "backend.app.services.runners.langgraph_runner.ChatOpenAI"
+            ) as MockChatOpenAI:
+                langgraph_runner._create_llm(mock_agent)
+                MockChatOpenAI.assert_called_once_with(
+                    model="test-model",
+                    base_url="http://localhost:8321/v1",
+                    api_key="test-key",
+                    temperature=0,
+                    streaming=True,
+                )
+
+    def test_create_llm_falls_back_to_llama_stack_url(
+        self, langgraph_runner, mock_agent
+    ):
+        """_create_llm builds base_url from LLAMA_STACK_URL when no explicit base set."""
+        with patch(
+            "backend.app.services.runners.langgraph_runner.settings"
+        ) as mock_settings:
+            mock_settings.LANGGRAPH_LLM_API_BASE = None
+            mock_settings.LANGGRAPH_LLM_API_KEY = "no-key"
+            mock_settings.LANGGRAPH_DEFAULT_MODEL = None
+            mock_settings.LLAMA_STACK_URL = "http://llamastack:8321"
+
+            with patch(
+                "backend.app.services.runners.langgraph_runner.ChatOpenAI"
+            ) as MockChatOpenAI:
+                langgraph_runner._create_llm(mock_agent)
+                MockChatOpenAI.assert_called_once()
+                call_kwargs = MockChatOpenAI.call_args[1]
+                assert call_kwargs["base_url"] == "http://llamastack:8321/v1"
+
+    def test_create_llm_uses_override_model(self, langgraph_runner, mock_agent):
+        """LANGGRAPH_DEFAULT_MODEL overrides agent.model_name."""
+        with patch(
+            "backend.app.services.runners.langgraph_runner.settings"
+        ) as mock_settings:
+            mock_settings.LANGGRAPH_LLM_API_BASE = "http://localhost/v1"
+            mock_settings.LANGGRAPH_LLM_API_KEY = "key"
+            mock_settings.LANGGRAPH_DEFAULT_MODEL = "override-model"
+            mock_settings.LLAMA_STACK_URL = None
+
+            with patch(
+                "backend.app.services.runners.langgraph_runner.ChatOpenAI"
+            ) as MockChatOpenAI:
+                langgraph_runner._create_llm(mock_agent)
+                call_kwargs = MockChatOpenAI.call_args[1]
+                assert call_kwargs["model"] == "override-model"
+
+
+# ---------------------------------------------------------------------------
+# Session title update
+# ---------------------------------------------------------------------------
+
+
+class TestSessionTitleUpdate:
+    """Test _update_session_title."""
+
+    @pytest.mark.asyncio
+    async def test_updates_title_from_text_prompt(
+        self, langgraph_runner, mock_db_session
+    ):
+        """Session title is updated from the first user message."""
+        mock_session = MagicMock()
+        mock_session.title = "Chat-20250101"
+        mock_session.user_id = langgraph_runner.user_id
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_session
+        mock_db_session.execute.return_value = mock_result
+
+        items = [SimpleNamespace(text="What is the weather in San Francisco?")]
+        await langgraph_runner._update_session_title("session-1", items)
+
+        assert mock_session.title == "What is the weather in San Francisco?"
+        mock_db_session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_if_title_already_set(self, langgraph_runner, mock_db_session):
+        """Does not overwrite a meaningful (non-'Chat…') title."""
+        mock_session = MagicMock()
+        mock_session.title = "Important conversation"
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_session
+        mock_db_session.execute.return_value = mock_result
+
+        await langgraph_runner._update_session_title("s1", [SimpleNamespace(text="hi")])
+
+        mock_db_session.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_handles_missing_session(self, langgraph_runner, mock_db_session):
+        """Gracefully handles session not found."""
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db_session.execute.return_value = mock_result
+
+        # Should not raise
+        await langgraph_runner._update_session_title("missing", "hello")


### PR DESCRIPTION
## Summary

- **Multi-framework runner abstraction**: Adds a `BaseRunner` layer so agents can be backed by LlamaStack (existing) or LangGraph, selected via `runner_type` on the agent model.
- **Declarative graph engine**: YAML-driven DAG of typed nodes (`llm`, `mcp_tool`, `mcp_tool_map`, `router`) with automatic dependency analysis that fans out independent nodes for **parallel execution**, significantly reducing end-to-end latency.
- **Vacation Planner template**: End-to-end travel planning agent using three new MCP servers (Tavily research, SerpApi hotels, SerpApi flights) orchestrated by the graph engine—hotel and flight searches now run concurrently with destination research.
- **Frontend streaming & rendering**: Real-time SSE progress with per-node expandable cards, inline status indicators (✓/spinner/○), and proper GFM markdown rendering via `remark-gfm` + PatternFly `pf-v6-c-content`.
- **Bug fixes**: Incremental template DB sync, MCP session retry for 404, IATA code resolution with city-airport map, LLM-based input field extraction from natural language.

## Test plan

- [ ] Deploy locally with `podman-compose -f deploy/local/compose.yaml up -d`
- [ ] Set `TAVILY_API_KEY` and `SERPAPI_API_KEY` in `.env` and recreate MCP containers
- [ ] Create a Vacation Planner agent from the template
- [ ] Send "Plan a weekend trip to Paris with food and sightseeing" and verify:
  - [ ] Multiple nodes start in parallel (hotel/flight appear before destination research finishes)
  - [ ] Each node's output renders as formatted markdown under expandable cards
  - [ ] Itinerary synthesises results from all prior nodes
- [ ] Run existing unit tests: `pytest tests/unit/`
- [ ] Run integration tests: `pytest tests/integration/`


Made with [Cursor](https://cursor.com)